### PR TITLE
docs: add post-PR reflection workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,18 @@ This includes:
 
 Do NOT skip the self-critique step. It catches bugs before they reach review.
 
+## Post-PR Reflection
+
+After completing a pull request, reflect on the conversation and look for generalizable mistakes or patterns that could have been prevented with better guidance in this file.
+
+If you identify improvements:
+
+1. Note specific lessons learned (e.g., "Always check X before Y", "Remember to handle edge case Z")
+2. Create a separate PR to the template repository (`alexander-turner/claude-automation-template`) adding these insights to `CLAUDE.md`
+3. Keep additions concise and actionable
+
+This continuous improvement loop helps prevent recurring issues across future sessions.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

- Adds a "Post-PR Reflection" section to CLAUDE.md instructing Claude to reflect on conversations after completing PRs
- Encourages identifying generalizable mistakes and contributing lessons learned back to the template repository
- Creates a continuous improvement loop for the template

## Test plan

- [x] Verified documentation reads clearly and is actionable
- [x] Confirmed session-setup.sh already installs `gh` via webi (line 56)
- [x] Self-critique passed with no blocking issues

https://claude.ai/code/session_01WkaU1pn8Juz1a8rvd878dL