### PR TITLE
Add TypeScript template literal guideline to coding standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ tests/            # Test files (create as needed)
 - Prefer throwing errors that "fail loudly" over logging warnings for critical issues
 - Un-nest conditionals where possible; combine related checks into single blocks
 - Create shared helpers when the same logic is needed in multiple places
+- In TypeScript, only use template literals if using variable substitution
 
 ### Testing
 


### PR DESCRIPTION
## Summary
Updated the coding standards documentation to clarify best practices for TypeScript template literal usage.

## Changes
- Added guideline to CLAUDE.md specifying that template literals should only be used when performing variable substitution
- This promotes consistency and discourages unnecessary template literal syntax for static strings

## Details
This guideline encourages developers to use regular strings (`"string"`) for static content and reserve template literals (`` `string` ``) only for cases where variable interpolation is actually needed. This improves code clarity and follows common TypeScript style conventions.

https://claude.ai/code/session_01UhtgHUTSeXEWaBae9USWmY