### PR TITLE
Make GitHub CLI authentication required in session setup

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -76,10 +76,8 @@ git config core.hooksPath .hooks
 # GitHub CLI auth
 #######################################
 
-if [ -n "${GH_TOKEN:-}" ] && command -v gh &>/dev/null; then
-  echo "Configuring GitHub authentication..."
-  echo "$GH_TOKEN" | gh auth login --with-token 2>&1 || warn "Failed to authenticate with GitHub"
-fi
+command -v gh &>/dev/null || die "gh CLI not found"
+[ -n "${GH_TOKEN:-}" ] || die "GH_TOKEN is not set — GitHub CLI requires authentication"
 
 #######################################
 # Project dependencies


### PR DESCRIPTION
## Summary
Changed the GitHub CLI authentication setup from optional to required, ensuring that both the `gh` CLI tool and `GH_TOKEN` environment variable are present before proceeding with session initialization.

## Changes
- Replaced conditional authentication logic with explicit validation checks
- Now fails fast with `die` if `gh` CLI is not installed
- Now fails fast with `die` if `GH_TOKEN` environment variable is not set
- Removed the warning-based approach in favor of hard requirements

## Details
The previous implementation would silently continue if GitHub CLI was unavailable or authentication failed. This change makes GitHub authentication a hard requirement for the session setup, ensuring that all downstream processes can rely on authenticated GitHub access. This is a stricter approach that prevents partial initialization states and makes configuration issues immediately visible.

https://claude.ai/code/session_01M3dzj9DSD8n8Jbk19D9EtF