### PR TITLE
fix: resolve set -e failure in template sync workflow

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -185,10 +185,8 @@ jobs:
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
             # Combine changed and new files, convert newlines to spaces
-            {
-              git diff --name-only
-              git ls-files --others --exclude-standard
-            } | tr '\n' ' ' | { read -r changed_paths; echo "changed_paths=$changed_paths" >> $GITHUB_OUTPUT; }
+            changed_paths=$({ git diff --name-only; git ls-files --others --exclude-standard; } | tr '\n' ' ')
+            echo "changed_paths=$changed_paths" >> $GITHUB_OUTPUT
           fi
 
       - name: Show diff (dry run)


### PR DESCRIPTION
## Summary
- Fix the "Sync from Template" workflow failing with exit code 1 when template updates include both new files and conflicts
- The root cause was a `read` command in a pipeline subshell returning exit code 1 under `set -e`, aborting the script before writing to `$GITHUB_OUTPUT`

## Changes
- Replaced the pipe-to-read pattern (`| { read -r var; echo ... }`) with a command substitution (`var=$(...)`) in `.github/workflows/template-sync.yaml`
- This avoids the subshell `set -e` issue since `read` no longer runs in a pipeline subshell that can exit prematurely
- The fix is consistent with the existing pattern already used on line 165 of the same file

## Testing
- Verified the YAML is valid and formatting passes (`pnpm format`)
- The fix addresses the exact failure seen in [CI run #21739307430](https://github.com/alexander-turner/TurnTrout.com/actions/runs/21739307430/job/62711247429)

https://claude.ai/code/session_01JrZSEewXXgN1BnawPPXqy5