### PR TITLE
Add code style rule against backward-looking comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ tests/            # Test files (create as needed)
 - Un-nest conditionals where possible; combine related checks into single blocks
 - Create shared helpers when the same logic is needed in multiple places
 - In TypeScript, only use template literals if using variable substitution
+- Comments should describe what code does and why, never reference deleted code or what "used to be" there (e.g., don't write "Do NOT use X" referring to removed code)
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- Adds a code style guideline: comments should describe what code does and why, never reference deleted code or what "used to be" there
- Prevents comments like "Do NOT use X" that only make sense if you know the prior implementation

## Context
While fixing Playwright tests in TurnTrout.com, a comment was added that referenced removed code ("Do NOT use addInitScript to clear localStorage"). This kind of comment is confusing to future readers who don't have context about what was there before. Adding this as a template-level guideline prevents the pattern across all downstream repos.

## Test plan
- [ ] Verify the new bullet point renders correctly in CLAUDE.md
- [ ] Confirm it integrates naturally with existing Code Style guidelines

https://claude.ai/code/session_01KCQ7wT52tMpyvjt2kejpjV