### PR TITLE
feat: add PR status check before updating existing PRs

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -50,7 +50,7 @@ Before updating an existing PR (pushing new commits, editing the description, et
 2. Based on the result:
    - **Open**: Proceed with the update normally
    - **Merged**: Do NOT update it. Create a new PR instead with the additional changes
-   - **Closed** (not merged): Ask the user what they'd like to do before taking any action
+   - **Closed** (not merged): Ask the user what they'd like to do, if not already clarified
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Adds a new "Updating an Existing PR" section to the pr-creation skill that requires checking PR state before attempting updates
- If a PR has been merged, a new PR should be created instead; if closed (not merged), the user should be consulted first

## Changes
- Added "Updating an Existing PR" section to `.claude/skills/pr-creation/SKILL.md` (placed after Prerequisites, before Workflow)
- Specifies using `gh pr view --json state` to check PR status
- Defines behavior for three states: open (proceed), merged (new PR), closed (ask user)

## Testing
- Verified formatting with `pnpm format` — no changes needed
- Pre-commit hooks (prettier, skill linter) passed on both commits

https://claude.ai/code/session_017B3EghBcQ9nbkEvbxgaiY5