### PR TITLE
fix: sync claude.yaml to child repos and use PAT for @claude trigger

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -34,7 +34,7 @@ on:
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"
   # Only sync core automation files that don't need customization
-  SYNC_PATHS: ".claude .hooks .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml"
+  SYNC_PATHS: ".claude .hooks .github/workflows/template-sync.yaml .github/workflows/dependabot-auto-merge.yaml .github/workflows/claude.yaml"
   # These are excluded because they require project-specific customization
   # (comment-on-failed-checks needs workflow names, lint/test need project scripts)
   EXCLUDE_PATHS: ""
@@ -235,7 +235,7 @@ jobs:
       - name: Request Claude review for conflicts
         if: inputs.dry-run != 'true' && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || github.token }}
         run: |
           gh pr comment "${{ steps.create-pr.outputs.pull-request-number }}" --body "@claude This template sync PR has conflicts - files that differ between the local repo and template. The local versions have been preserved. Please suggest how to merge each conflicting file, keeping project-specific customizations while adopting template improvements.
 


### PR DESCRIPTION
## Summary

Fixes two issues that prevent `@claude` mentions in template-sync conflict PRs from triggering Claude for GitHub.

### Changes to `template-sync.yaml`

1. **Add `claude.yaml` to `SYNC_PATHS`** — The template has `.github/workflows/claude.yaml` (using `anthropics/claude-code-action@v1`), but it was never synced to child repos. Without it, `@claude` mentions just ping the unrelated GitHub user [claude](https://github.com/claude) instead of triggering the action.

2. **Use `TEMPLATE_SYNC_TOKEN` for the `@claude` comment** — The comment step was using `github.token`. GitHub [prevents `GITHUB_TOKEN`-authored events from triggering other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to avoid infinite loops. Since `claude.yaml` triggers on `issue_comment`, a `github.token`-posted comment would never trigger it.

### Observed behavior

[PR #578 on TurnTrout.com](https://github.com/alexander-turner/TurnTrout.com/pull/578) — `@claude` comment posted by template-sync, no response from Claude.

Fixes #28

## Test plan

- [ ] Run template-sync manually on a child repo with conflicts
- [ ] Verify `claude.yaml` gets synced to the child repo
- [ ] Verify the `@claude` comment triggers the claude-code-action workflow

https://claude.ai/code/session_01MWkQooaJsiJcY2DE7gMt8G