### PR TITLE
docs: add descriptive variable naming guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ tests/            # Test files (create as needed)
 - Prefer throwing errors that "fail loudly" over logging warnings for critical issues
 - Un-nest conditionals where possible; combine related checks into single blocks
 - Create shared helpers when the same logic is needed in multiple places
+- Use descriptive variable names; don't shorten for brevity
 - In TypeScript, only use template literals if using variable substitution
 - Comments should describe what code does and why, never reference deleted code or what "used to be" there (e.g., don't write "Do NOT use X" referring to removed code)
 


### PR DESCRIPTION
## Summary
- Add "Use descriptive variable names; don't shorten for brevity" to Code Style section

Learned from the punctilio prime conversion refactor — shortened variables (`chr`, `eq`, `L`) hurt readability in complex logic. Renamed to `escapedSeparator`, `escapedQuote`, and used `LATIN_LETTERS` inline.

The regex-specific guidance ("split complex regex into pattern builder + replace callback") was too project-specific for the template.

https://claude.ai/code/session_01AkAfmNdDS2DKW69UHxyruV