### PR TITLE
fix: add .venv/bin to PATH after uv sync

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -122,6 +122,14 @@ fi
 # Install Python dependencies if uv.lock exists
 if [ -f "$PROJECT_DIR/uv.lock" ] && command -v uv &>/dev/null; then
 	uv sync --quiet 2>/dev/null || warn "Failed to sync Python dependencies"
+	# Add .venv/bin to PATH so Python tools (autoflake, isort, autopep8, etc.)
+	# installed by uv sync are available to lint-staged and other commands
+	if [ -d "$PROJECT_DIR/.venv/bin" ]; then
+		export PATH="$PROJECT_DIR/.venv/bin:$PATH"
+		if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+			echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
+		fi
+	fi
 fi
 
 if [ "$SETUP_WARNINGS" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- Python tools installed by `uv sync` (autoflake, isort, autopep8, etc.) land in `.venv/bin/`, but that directory was never added to PATH
- This causes pre-commit hooks to fail with `ENOENT` when `lint-staged` invokes these tools directly
- After `uv sync`, add `.venv/bin` to both the current PATH and `CLAUDE_ENV_FILE` so tools remain available throughout the session

## Test plan
- [x] Verified fix in TurnTrout.com repo — pre-commit hooks now find autoflake, isort, autopep8 without manual `pip install`
- [ ] Confirm session-setup.sh runs without errors on a fresh session

https://claude.ai/code/session_015bPHjrHiZdSEheZWqXk6xj