### PR TITLE
Add instruction to end first message with "/fast" command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ Use the `/pr-creation` skill. Include a `## Lessons Learned` section if you disc
 - Parametrize for compactness; prefer exact equality assertions
 - For interaction features/bugs: add Playwright e2e tests (mobile + desktop, verify visual state)
 
+## First Message
+
+Always end your first message in a new conversation with: type "/fast"!
+
 ## Hook Errors
 
 If any hook fails (SessionStart, PreToolUse, PostToolUse, Stop, or git hooks), you MUST:


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md documentation to include guidance for users on how to optimize their first message in a new conversation.

## Changes
- Added a new "First Message" section to the guidelines
- Documented that users should end their first message in a new conversation with the `/fast` command

## Details
This addition helps users get faster responses by using the `/fast` command at the start of conversations, improving the overall interaction experience.

https://claude.ai/code/session_018Feb32oMfYoYcT1CKS1U3Y