### PR TITLE
Remove hardcoded fast mode reminder from session setup

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -132,5 +132,3 @@ fi
 if [ "$SETUP_WARNINGS" -gt 0 ]; then
 	echo "Setup done with $SETUP_WARNINGS warning(s) — see above" >&2
 fi
-
-echo 'In your first response, remind the user to type "/fast" to enable fast mode.'


### PR DESCRIPTION
## Summary
Removed a hardcoded echo statement that was instructing users to type "/fast" to enable fast mode from the session setup script.

## Changes
- Removed the line that echoed a reminder about fast mode activation from the end of `session-setup.sh`

## Details
This removes what appears to be a debugging or temporary instruction that was being printed to users during session initialization. The fast mode reminder is no longer output as part of the setup process, allowing for cleaner session setup output or deferring this instruction to be handled elsewhere if needed.

https://claude.ai/code/session_01V6xQaf34s3Ng1XLimcHH3t