### PR TITLE
fix(skills): add --base flag to gh pr create template

### DIFF
--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -11,7 +11,7 @@ EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --j
 If `EXISTING_PR` is non-empty, update the existing PR with `gh pr edit` instead of creating a new one.
 
 ```bash
-gh pr create --title "<type>: <description>" --body "$(cat <<'EOF'
+gh pr create --base "$CLAUDE_CODE_BASE_REF" --title "<type>: <description>" --body "$(cat <<'EOF'
 ## Summary
 <1-3 bullet points describing what changed and why>
 


### PR DESCRIPTION
## Summary
- The `gh pr create` example in `pr-templates.md` was missing `--base "$CLAUDE_CODE_BASE_REF"`, causing PRs to default to the repo's default branch instead of the intended base branch set by the environment

## Changes
- Added `--base "$CLAUDE_CODE_BASE_REF"` to the `gh pr create` command in `.claude/skills/pr-creation/pr-templates.md`

## Testing
- Discovered in downstream repo (TurnTrout.com) where PRs were incorrectly targeting `main` instead of `dev`
- Verified the fix resolves the issue

https://claude.ai/code/session_01ApE6PZkSpCiM6EJ8V6P3S6