### PR TITLE
Fix critique prompt path reference in PR creation skill

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -63,7 +63,7 @@ Before updating an existing PR (pushing new commits, editing the description, et
 
 ### Step 2: Self-Critique
 
-**Before creating the PR**, you MUST read [critique-prompt.md](critique-prompt.md) and launch a critique sub-agent using the Task tool:
+**Before creating the PR**, you MUST read the critique prompt at `.claude/skills/pr-creation/critique-prompt.md` and launch a critique sub-agent using the Task tool:
 
 - `subagent_type`: "general-purpose"
 - `description`: "Critique code changes"


### PR DESCRIPTION
## Summary
Updated the documentation reference to the critique prompt file to use an absolute path instead of a relative path reference.

## Changes
- Updated the path reference in the PR creation skill documentation from `critique-prompt.md` to `.claude/skills/pr-creation/critique-prompt.md` to provide clearer, more explicit guidance on the location of the critique prompt file

## Details
This change improves clarity for users following the PR creation workflow by providing the full path to the critique prompt file, making it easier to locate the resource regardless of the current working directory context.

https://claude.ai/code/session_01ShSkMufFysYxJ2f8Wyq1YQ