### PR TITLE
fix: fetch CLAUDE_CODE_BASE_REF in session setup

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -79,6 +79,13 @@ rm -f "${RETRY_DIR}/attempts-${PROJ_HASH}"
 cd "$PROJECT_DIR" || exit 1
 git config core.hooksPath .hooks
 
+# Pre-fetch the base branch so diffs against $CLAUDE_CODE_BASE_REF work
+# immediately (e.g. when creating PRs). Failure is non-fatal.
+if [ -n "${CLAUDE_CODE_BASE_REF:-}" ]; then
+	git fetch origin "$CLAUDE_CODE_BASE_REF" --quiet 2>/dev/null ||
+		warn "Failed to fetch base branch $CLAUDE_CODE_BASE_REF"
+fi
+
 #######################################
 # GitHub CLI auth
 #######################################


### PR DESCRIPTION
## Summary
- Pre-fetch the base branch (`$CLAUDE_CODE_BASE_REF`) during session startup so PR diffs work immediately without manual fetching

## Changes
- **`.claude/hooks/session-setup.sh`**: After git config setup, fetch `$CLAUDE_CODE_BASE_REF` if set. Non-fatal on failure.

## Testing
- Verified the env var is available during session setup
- Failure to fetch (e.g., branch doesn't exist yet) is handled gracefully via `warn`

## Lessons Learned
- The PR creation skill references `$CLAUDE_CODE_BASE_REF` for diffs, but the branch isn't always fetched locally in web sessions where the proxy only provides the current branch. Session setup should pre-fetch it.

https://claude.ai/code/session_01E7UW5BauYeEXF4cnDZHbLk