### PR TITLE
feat(skills): add dynamic PR title/description updates to PR skills

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -93,16 +93,27 @@ You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatt
    If a PR already exists, update it with `gh pr edit` instead of creating a new one.
 3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
 
-After creating the PR, and after any subsequent fix commits, update the PR description with `gh pr edit --body "..."` to reflect the current state of all changes.
+### Step 6: Update PR Title and Description After Fixes
 
-### Step 6: Wait for CI Checks (MANDATORY)
+After any fix commits (from critique, validation, or CI failures), **always** update the PR title and description to reflect the final state of all changes:
+
+```bash
+gh pr edit --title "<type>: <updated description>" --body "$(cat <<'EOF'
+<updated body using template from pr-templates.md>
+EOF
+)"
+```
+
+The title and description must describe the **current totality** of changes, not just the original scope. Re-read the diff (`git diff $CLAUDE_CODE_BASE_REF...HEAD`) to ensure accuracy.
+
+### Step 7: Wait for CI Checks (MANDATORY)
 
 1. Run `gh pr checks <pr-number> --watch` to monitor
 2. If any checks fail, investigate and fix the issues
-3. Push fixes and wait again
+3. Push fixes, update the PR description (Step 6), and wait again
 4. Only proceed once all checks are green
 
-### Step 7: Report Result
+### Step 8: Report Result
 
 Provide the PR URL and confirm all CI checks have passed.
 
@@ -124,8 +135,9 @@ Provide the PR URL and confirm all CI checks have passed.
    ```
    gh pr create --title "fix: handle null session token in login flow" --body "..."
    ```
-8. Watches CI with `gh pr checks 47 --watch` — all green
-9. Reports: "PR #47 created and all CI checks pass: https://github.com/org/repo/pull/47"
+8. Updates PR description to reflect the null-check fix added during critique
+9. Watches CI with `gh pr checks 47 --watch` — all green
+10. Reports: "PR #47 created and all CI checks pass: https://github.com/org/repo/pull/47"
 
 ### Example 2: Multi-Commit Feature
 
@@ -141,9 +153,10 @@ Provide the PR URL and confirm all CI checks have passed.
 6. Re-runs critique (>3 fixes) — clean this time
 7. Runs validation — all pass
 8. Pushes and creates PR with detailed body summarizing the feature
-9. Watches CI — one check fails (lint warning on new file)
-10. Fixes lint issue, pushes, watches again — all green
-11. Reports success with PR URL
+9. Updates PR title and description to reflect all changes including critique fixes
+10. Watches CI — one check fails (lint warning on new file)
+11. Fixes lint issue, pushes, updates PR description again — all green
+12. Reports success with PR URL
 
 ### Example 3: When Input Is Unclear
 

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -93,18 +93,20 @@ You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatt
    If a PR already exists, update it with `gh pr edit` instead of creating a new one.
 3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
 
-### Step 6: Update PR Title and Description After Fixes
+### Step 6: Update PR Title and Description (after any post-creation changes)
 
-After any fix commits (from critique, validation, or CI failures), **always** update the PR title and description to reflect the final state of all changes:
+If you made any commits after creating the PR (from critique, validation, or CI failures), **always** update the PR title and description to reflect the final state of all changes:
 
-```bash
-gh pr edit --title "<type>: <updated description>" --body "$(cat <<'EOF'
-<updated body using template from pr-templates.md>
-EOF
-)"
-```
+1. Re-read the diff (`git diff $CLAUDE_CODE_BASE_REF...HEAD`) and commit log (`git log $CLAUDE_CODE_BASE_REF..HEAD --oneline`) to see the full scope
+2. Rewrite the title and body to accurately describe the **current totality** of changes, not just the original scope:
+   ```bash
+   gh pr edit <pr-number> --title "<type>: <updated description>" --body "$(cat <<'EOF'
+   <updated body using template from pr-templates.md>
+   EOF
+   )"
+   ```
 
-The title and description must describe the **current totality** of changes, not just the original scope. Re-read the diff (`git diff $CLAUDE_CODE_BASE_REF...HEAD`) to ensure accuracy.
+Skip this step if no commits were made after Step 5.
 
 ### Step 7: Wait for CI Checks (MANDATORY)
 

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -53,15 +53,30 @@ Use the `/commit` skill to create conventional commits:
 git push
 ```
 
-### 5. Verify CI (with 15-minute timeout)
+### 5. Update PR Title and Description
+
+After pushing, dynamically update the PR to reflect **all** changes (not just the latest commit):
+
+1. Run `git diff $CLAUDE_CODE_BASE_REF...HEAD` and `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline` to see the full scope
+2. Read `.claude/skills/pr-creation/pr-templates.md` for the PR template format
+3. Rewrite the title and body to accurately describe the **current state** of the PR:
+   ```bash
+   gh pr edit --title "<type>: <updated description>" --body "$(cat <<'EOF'
+   <updated body using template from pr-templates.md>
+   EOF
+   )"
+   ```
+4. The title and summary should reflect the totality of the PR, not just the new changes
+
+### 6. Verify CI (with 15-minute timeout)
 
 ```bash
 timeout 15m gh pr checks --watch || true
 ```
 
-The stop hook (`verify_ci.py`) will automatically block completion if CI fails. If checks fail, fix issues and repeat steps 3-5.
+The stop hook (`verify_ci.py`) will automatically block completion if CI fails. If checks fail, fix issues and repeat steps 3-6.
 
-### 6. Report Result
+### 7. Report Result
 
 Confirm the PR is updated and provide the URL.
 
@@ -69,10 +84,10 @@ Confirm the PR is updated and provide the URL.
 
 **User:** "Fix the type error in the PR"
 
-**Actions:** Verify PR exists → Fix type error → `/commit` → Push → Verify CI → Report URL
+**Actions:** Verify PR exists → Fix type error → `/commit` → Push → Update PR title/description → Verify CI → Report URL
 
 ## Error Handling
 
 - **No PR for branch**: Ask if they want to create one (`/pr-creation`)
 - **PR merged/closed**: Ask user what to do (don't modify merged PRs)
-- **CI fails**: Fix issues and push again (stop hook enforces this)
+- **CI fails**: Fix issues, push again, and update the PR description (stop hook enforces this)

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -61,7 +61,7 @@ After pushing, dynamically update the PR to reflect **all** changes (not just th
 2. Read `.claude/skills/pr-creation/pr-templates.md` for the PR template format
 3. Rewrite the title and body to accurately describe the **current state** of the PR:
    ```bash
-   gh pr edit --title "<type>: <updated description>" --body "$(cat <<'EOF'
+   gh pr edit <pr-number> --title "<type>: <updated description>" --body "$(cat <<'EOF'
    <updated body using template from pr-templates.md>
    EOF
    )"


### PR DESCRIPTION
## Summary

- The `update-pr` skill had no step for updating the PR title/description after pushing changes — it just committed, pushed, and verified CI
- The `pr-creation` skill mentioned description updates in a single buried line that was easy to miss and didn't cover title updates
- Both skills now have explicit, numbered workflow steps that require re-reading the full diff and rewriting the PR title and description to reflect the current totality of changes

## Changes

- **`update-pr/SKILL.md`**: Added new Step 5 ("Update PR Title and Description") with instructions to run `git diff`/`git log`, reference `pr-templates.md`, and rewrite both title and body via `gh pr edit <pr-number>`. Updated step numbering, example, and error handling throughout.
- **`pr-creation/SKILL.md`**: Promoted the one-liner into Step 6 ("Update PR Title and Description (after any post-creation changes)") with explicit `git diff`/`git log` instructions and a skip condition when no post-creation commits exist. Updated step numbering, examples, and CI retry references.

## Testing

Documentation-only change — verified via lint-skills hook and prettier formatting.

https://claude.ai/code/session_016LqGiGcbLL5bQ2qi4qk4jg