### PR TITLE
Improve template changelog generation for force-pushed repos

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -114,7 +114,13 @@ jobs:
 
           # Generate changelog between versions if we have a previous SHA
           if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$TEMPLATE_SHA" ]; then
-            CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA" 2>/dev/null || echo "Could not generate changelog (previous SHA may no longer exist)")
+            if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
+              CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA")
+            else
+              echo "::warning::Previous template SHA $PREV_SHA not found in template history (likely rewritten by force-push or rebase)"
+              CHANGELOG="Previous SHA \`$PREV_SHA\` no longer exists in template history (force-push/rebase). Showing last 20 commits instead:"$'\n'
+              CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA")
+            fi
             if [ -n "$CHANGELOG" ]; then
               echo "changelog<<CHANGELOG_DELIMITER_8a2b1c" >> "$GITHUB_OUTPUT"
               echo "$CHANGELOG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Enhanced the template sync workflow to gracefully handle cases where the previous template SHA no longer exists in the repository history, which can occur when a template repository is force-pushed or rebased.

## Key Changes
- Added explicit validation of the previous SHA before attempting to generate a changelog using `git cat-file -e`
- When the previous SHA is not found, the workflow now:
  - Emits a GitHub warning to alert users about the history rewrite
  - Falls back to displaying the last 20 commits from the current template SHA instead of failing
  - Provides clear messaging to users explaining why the full changelog couldn't be generated
- Improved error handling by distinguishing between a missing SHA (history rewrite) and other potential failures

## Implementation Details
- Uses `git cat-file -e` to check if a commit object exists before attempting to reference it
- Maintains backward compatibility by still generating a changelog when the previous SHA is available
- The fallback behavior ensures the workflow continues successfully even when template history has been rewritten

https://claude.ai/code/session_016FqFwvgXjJGM6dAGT4rN61