### PR TITLE
docs: add repo PR guidance checks and remove session URLs

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -60,6 +60,7 @@ Before updating an existing PR (pushing new commits, editing the description, et
 2. Run `git diff <base-branch>...HEAD` to see all changes
 3. Run `git log <base-branch>..HEAD --oneline` to see all commits
 4. Review the changed files to understand the scope
+5. **Check for PR description guidance** — look for `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or similar files in the repo. If found, read them and adapt the PR description to follow the repository's conventions (see [pr-templates.md](pr-templates.md) for details)
 
 ### Step 2: Self-Critique
 

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -1,6 +1,6 @@
 # PR Templates and Formatting Reference
 
-## Check for Repository PR Guidance (MANDATORY)
+## Check for Repository PR Guidance
 
 Before writing any PR description, check the repository for guidance on how to structure PRs:
 
@@ -63,7 +63,6 @@ Use imperative mood with a Conventional Commits type prefix:
 - List concrete changes
 - Note any breaking changes
 - Include a "Lessons Learned" section if you discovered generalizable insights that could improve the template (this triggers the phone-home workflow). Each lesson must specify **what** to change, **where**, and **why** — vague observations get ignored. Delete the section entirely if there are no lessons.
-- **Never** include `claude.ai` URLs or session links
 
 ## Updating PR Description After Additional Commits
 

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -1,5 +1,19 @@
 # PR Templates and Formatting Reference
 
+## Check for Repository PR Guidance (MANDATORY)
+
+Before writing any PR description, check the repository for guidance on how to structure PRs:
+
+1. Look for `CONTRIBUTING.md`, `CONTRIBUTING`, or `.github/CONTRIBUTING.md`
+2. Look for `.github/PULL_REQUEST_TEMPLATE.md` or `.github/PULL_REQUEST_TEMPLATE/`
+3. Look for `docs/CONTRIBUTING.md` or `docs/contributing.md`
+
+If any of these exist, **read them** and adapt your PR description to follow the repository's conventions. Repository-specific guidance takes precedence over the default template below. Merge both: use the repo's structure/sections but still include the Lessons Learned section from this template if applicable.
+
+## IMPORTANT: No Session Links
+
+**NEVER** include `claude.ai` URLs, session links, or any AI-tool attribution links in PR titles, descriptions, or comments. These are internal tracking artifacts and do not belong in PRs.
+
 ## PR Creation Command
 
 First, check if a PR already exists for the current branch:
@@ -28,8 +42,6 @@ gh pr create --base "$CLAUDE_CODE_BASE_REF" --title "<type>: <description>" --bo
 - **What**: <concrete change — e.g., "Add X to CLAUDE.md", "Hook Y should also check Z">
 - **Where**: <file or component — e.g., `CLAUDE.md`, `session-setup.sh`, `phone-home.yaml`>
 - **Why**: <1-2 sentences — what went wrong or was discovered>
-
-https://claude.ai/code/session_...
 EOF
 )"
 ```
@@ -51,7 +63,7 @@ Use imperative mood with a Conventional Commits type prefix:
 - List concrete changes
 - Note any breaking changes
 - Include a "Lessons Learned" section if you discovered generalizable insights that could improve the template (this triggers the phone-home workflow). Each lesson must specify **what** to change, **where**, and **why** — vague observations get ignored. Delete the section entirely if there are no lessons.
-- Include the Claude session URL at the end
+- **Never** include `claude.ai` URLs or session links
 
 ## Updating PR Description After Additional Commits
 
@@ -72,8 +84,6 @@ gh pr edit --body "$(cat <<'EOF'
 - **What**: <concrete change>
 - **Where**: <file or component>
 - **Why**: <what went wrong or was discovered>
-
-https://claude.ai/code/session_...
 EOF
 )"
 ```

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -10,10 +10,6 @@ Before writing any PR description, check the repository for guidance on how to s
 
 If any of these exist, **read them** and adapt your PR description to follow the repository's conventions. Repository-specific guidance takes precedence over the default template below. Merge both: use the repo's structure/sections but still include the Lessons Learned section from this template if applicable.
 
-## IMPORTANT: No Session Links
-
-**NEVER** include `claude.ai` URLs, session links, or any AI-tool attribution links in PR titles, descriptions, or comments. These are internal tracking artifacts and do not belong in PRs.
-
 ## PR Creation Command
 
 First, check if a PR already exists for the current branch:

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -58,15 +58,16 @@ git push
 After pushing, dynamically update the PR to reflect **all** changes (not just the latest commit):
 
 1. Run `git diff $CLAUDE_CODE_BASE_REF...HEAD` and `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline` to see the full scope
-2. Read `.claude/skills/pr-creation/pr-templates.md` for the PR template format
-3. Rewrite the title and body to accurately describe the **current state** of the PR:
+2. Check for `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or similar PR description guidance in the repo — if found, adapt the description to follow the repository's conventions
+3. Read `.claude/skills/pr-creation/pr-templates.md` for the PR template format and merge with any repo-specific guidance
+4. Rewrite the title and body to accurately describe the **current state** of the PR:
    ```bash
    gh pr edit <pr-number> --title "<type>: <updated description>" --body "$(cat <<'EOF'
    <updated body using template from pr-templates.md>
    EOF
    )"
    ```
-4. The title and summary should reflect the totality of the PR, not just the new changes
+5. The title and summary should reflect the totality of the PR, not just the new changes
 
 ### 6. Verify CI (with 15-minute timeout)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 ## Pull Requests
 
-Use the `/pr-creation` skill. Include a `## Lessons Learned` section if you discovered generalizable insights — the `phone-home.yaml` workflow propagates these to the template repo on merge. Each lesson must be actionable: specify **what** to change, **where** (file/component), and **why**. Delete the section entirely if there are no lessons — empty or vague lessons create noise.
+Use the `/pr-creation` skill. Before writing a PR description, check for `CONTRIBUTING.md` or `.github/PULL_REQUEST_TEMPLATE.md` in the target repo and follow its conventions. **Never** include `claude.ai` URLs, session links, or AI-tool attribution links in PRs. Include a `## Lessons Learned` section if you discovered generalizable insights — the `phone-home.yaml` workflow propagates these to the template repo on merge. Each lesson must be actionable: specify **what** to change, **where** (file/component), and **why**. Delete the section entirely if there are no lessons — empty or vague lessons create noise.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Updated PR creation and update guidance to prioritize repository-specific PR conventions and remove Claude session URL references from PR descriptions.

## Key Changes

- **pr-templates.md**: Added new "Check for Repository PR Guidance" section that instructs users to look for `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and related files before writing PR descriptions, with guidance to merge repo-specific conventions with the default template
- **pr-templates.md**: Removed instructions to include Claude session URLs in PR descriptions (both in initial creation and update workflows)
- **update-pr/SKILL.md**: Added step to check for repository PR description guidance before updating PR descriptions, with reference to the new guidance in pr-templates.md
- **CLAUDE.md**: Updated PR section to emphasize checking for repository-specific PR conventions and explicitly prohibit including `claude.ai` URLs, session links, or AI-tool attribution in PRs

## Rationale

These changes ensure that:
1. Generated PRs respect repository maintainer conventions and expectations
2. Claude session URLs (which are internal/temporary) don't appear in public PRs
3. PR descriptions are professional and focused on the actual changes rather than tool metadata
4. Users have clear, centralized guidance on adapting to different repository standards

https://claude.ai/code/session_01AXhWm5kuS7s5ScBY6Y4t8N