### PR TITLE
Add weekly security vulnerability scan and remediation workflow

### DIFF
--- a/.github/prompts/security-vulnerability-scan.md
+++ b/.github/prompts/security-vulnerability-scan.md
@@ -1,0 +1,122 @@
+# Security Vulnerability Triage, Fix & Dependency Consolidation
+
+You are a security analyst triaging vulnerability alerts from GitHub's security features (Dependabot, code scanning, secret scanning), `pnpm audit`, and Socket.dev reports from CI. You are _also_ responsible for subsuming any open dependabot PRs into this same branch so the repository ends up with a single rollup PR instead of dozens of one-off dependency PRs.
+
+## Your Task
+
+1. Triage the raw security data provided
+2. Subsume every open dependabot PR into this branch (see "Subsuming dependabot PRs" below)
+3. Apply fixes for actionable issues
+4. Fix anything CI flags as broken by the bumps (see "When CI complains")
+5. Open or update a single PR with all of it
+
+## Triage Criteria
+
+For each alert, assess:
+
+1. **Exploitability**: Is this dependency/code reachable in production? A vulnerability in a dev-only tool is lower priority than one in a runtime dependency.
+2. **Severity context**: Does the CVSS score match the actual risk for this project? A "critical" SQL injection in a library used only for static-site builds may be effectively low risk.
+3. **Actionability**: Is there a fix available (patched version, workaround)?
+4. **Duplicates**: Group related alerts (e.g., multiple CVEs in the same package that would all be fixed by one upgrade).
+
+## Applying Fixes
+
+For each actionable finding (critical/high with available fixes, or medium with straightforward fixes):
+
+- **Dependency vulnerabilities**: Run `pnpm update <pkg>` or add a `pnpm.overrides` entry in `package.json` if a direct update isn't possible. Run `pnpm install` after changes.
+- **Python deps (uv)**: Run `uv lock --upgrade-package <pkg>` if the project uses `uv.lock`.
+- **Code vulnerabilities**: Edit the source files to fix the issue (e.g., add input sanitization, fix unsafe patterns).
+- **GitHub Actions issues**: Pin action versions to SHA hashes, fix permission scopes, etc.
+- **Socket.dev alerts**: Review alerts from recent PRs. For "Warn" severity alerts, assess whether they are false positives (e.g., generated lookup tables flagged as "obfuscated code") or genuine risks. Fix genuine risks via dependency updates or overrides. For false positives in well-known packages, suppress them in `.socket.yml` with an explanatory comment.
+
+**Do NOT fix:**
+
+- Low-severity findings that are dev-only and not exploitable
+- Issues where no fix is available upstream — note these in the PR description instead
+
+After applying fixes, run `pnpm check` and `pnpm test` (and `pytest` if the project uses Python) to verify nothing is broken. If tests fail due to your changes, fix them or revert the breaking change.
+
+## Subsuming dependabot PRs
+
+The workflow hands you a list of open dependabot PRs in the `DEPENDABOT_PRS` block. For each one:
+
+1. Read the PR body (`gh pr view <n>`) so you know the target versions.
+2. Apply the version bumps to `package.json` / `pyproject.toml` / workflow files directly on the current branch — do not merge the dependabot branch (it almost always conflicts).
+3. Regenerate locks: `pnpm install` for npm updates, `uv lock --upgrade-package <pkg>` for uv updates.
+4. After each batch, run `pnpm check` and `pnpm test`. If a test or a CI check fails because of a bump, see "When CI complains" below.
+5. Once the changes are committed, close the original PR with a comment pointing to your PR:
+
+   ```bash
+   gh pr close <n> --comment "Superseded by #<this-PR>."
+   ```
+
+   Do this only after your changes are merged into your branch — never before.
+
+Grouped dependabot PRs (`npm-all`, `uv-all`, `actions-all`) supersede the individual single-package PRs covering the same ecosystem; apply the group bump first, then close any individual PRs whose updates are covered by it.
+
+## When CI complains
+
+A bump occasionally breaks peer deps, types, or downstream plugins. Do **not** mask the failure — do the minimum investigation and choose one:
+
+1. **Pin back + ignore**: revert just the offending package to the last-known-good version and add an entry under the matching `ignore:` block in `.github/dependabot.yml` (use `versions: [">=<major>"]`). Note the reason in a comment so the ignore can be lifted once upstream is fixed.
+2. **Add a follow-up prompt**: if the fix is non-trivial (e.g. a plugin crashes on a new eslint major), write a small task prompt under `.github/prompts/fix-<topic>.md` describing the repro and remediation options, so a later run can pick it up.
+3. **Fix it now**: if the root cause is obvious and local (a rename, an API change), just apply the fix in the same PR.
+
+Call out whichever option you chose in the PR body under "Deferred Issues" so reviewers know what still needs attention.
+
+## Creating or Updating the PR
+
+After applying all fixes, check whether you're already on an existing security-fixes branch (the workflow tells you this in the prompt). If so, commit and push to that branch, then update the existing PR description. If not, create a new branch and PR.
+
+Before writing the PR body, check for `CONTRIBUTING.md` or `.github/PULL_REQUEST_TEMPLATE.md` and follow its conventions. **Never** include `claude.ai` URLs, session links, or AI-tool attribution links in the PR body.
+
+### New PR
+
+1. Create a branch: `git checkout -b security-fixes/YYYY-MM-DD` (using today's date)
+2. Commit all changes with a descriptive message: `fix(security): <summary of fixes applied>` (Conventional Commits — the `commit-msg` hook enforces this)
+3. Push and create a PR:
+
+```bash
+git push -u origin HEAD
+gh pr create \
+  --title "fix(security): weekly vulnerability remediation" \
+  --label "security-scan" \
+  --body-file /tmp/pr-body.md
+```
+
+### Existing PR
+
+1. Commit your fixes on the current branch: `fix(security): <summary of fixes applied>`
+2. Push: `git push`
+3. Update the PR body: `gh pr edit --body-file /tmp/pr-body.md`
+4. Include a cumulative summary of all fixes (old and new) in the PR body
+
+Write the PR body to `/tmp/pr-body.md` first (to avoid shell injection). The PR body should contain:
+
+### PR Body Format
+
+```markdown
+## Summary
+
+Automated security fixes and dependency consolidation from the weekly scan.
+
+## Fixes Applied
+
+- List each security fix with the alert it addresses.
+
+## Subsumed Dependabot PRs
+
+- `#<n>` <title> — closed as superseded.
+
+## Deferred Issues
+
+- List findings / bumps that could not be applied automatically, and why (e.g. "eslint 10 blocked on eslint-plugin-react — see .github/prompts/fix-eslint-plugin-react.md").
+
+## Validation
+
+- Results of `pnpm check` and `pnpm test`.
+```
+
+## If No Fixes Are Needed
+
+If there are no actionable findings to fix (all alerts are low-risk, dev-only, or have no available fix) AND there are no dependabot PRs to subsume, do NOT create a PR. Instead, output a summary of the scan results explaining why no action was taken.

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -1,0 +1,176 @@
+name: Weekly Security & Dependency Remediation
+
+# Runs weekly to:
+#   1. Collect open security alerts (Dependabot, code scanning, secret scanning,
+#      pnpm audit, Socket.dev) into a single report.
+#   2. Hand that report and the list of open dependabot PRs to Claude.
+#   3. Claude subsumes the dependabot PRs, applies security fixes, and opens /
+#      updates a single rollup PR (labeled `security-scan`).
+#
+# Pairs with `dependabot-auto-merge.yaml` — that workflow greenlights routine
+# minor/patch bumps, this one sweeps up whatever's left plus security work.
+
+concurrency:
+  group: security-vulnerability-scan
+  cancel-in-progress: false
+
+on:
+  schedule:
+    # Every Monday at 9am UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual triggering
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  security-events: read
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup base environment
+        uses: ./.github/actions/setup-base-env
+        with:
+          setup-python: ${{ hashFiles('uv.lock') != '' && 'true' || 'false' }}
+
+      - name: Check for existing security PR branch
+        id: existing-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if there's an open PR with the security-scan label
+          EXISTING_BRANCH=$(gh pr list --label "security-scan" --state open --json headRefName --jq '.[0].headRefName // empty')
+          if [ -n "$EXISTING_BRANCH" ]; then
+            echo "Found existing security PR branch: $EXISTING_BRANCH"
+            git fetch origin "$EXISTING_BRANCH"
+            git checkout "$EXISTING_BRANCH"
+            if ! git merge "origin/${{ github.event.repository.default_branch }}" --no-edit; then
+              echo "::error::Merge conflict with default branch. Aborting merge."
+              git merge --abort
+              exit 1
+            fi
+            echo "branch=$EXISTING_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No existing security PR found, will create new branch"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: List open dependabot PRs to subsume
+        id: dependabot-prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Collect open dependabot PRs so the triage step can consolidate
+          # them into the security branch and close the originals as superseded.
+          sentinel="PR_EOF_$(uuidgen)"
+          if ! listing=$(gh pr list \
+              --state open \
+              --search "author:app/dependabot" \
+              --json number,title,headRefName,headRefOid,url \
+              --jq '.[] | "- #\(.number) [\(.headRefName)@\(.headRefOid[0:7])] \(.title) — \(.url)"'); then
+            listing="_Failed to list dependabot PRs — investigate before relying on subsume step._"
+          fi
+          {
+            echo "DEPENDABOT_PRS<<${sentinel}"
+            printf '%s\n' "${listing}"
+            echo "${sentinel}"
+          } >> "$GITHUB_ENV"
+
+      - name: Fetch GitHub security alerts
+        id: alerts
+        env:
+          # Dependabot and secret scanning APIs require a PAT with security_events scope;
+          # GITHUB_TOKEN lacks these permissions. Fall back to GITHUB_TOKEN for pnpm audit.
+          GH_TOKEN: ${{ secrets.PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+
+          # Dependabot alerts (open only)
+          echo "## Dependabot Alerts" > /tmp/security-report.md
+          gh api "repos/${REPO}/dependabot/alerts?state=open&per_page=100" \
+            --jq '.[] | "- **\(.security_advisory.severity | ascii_upcase)**: [\(.security_advisory.summary)](https://github.com/'"${REPO}"'/security/dependabot/\(.number)) in `\(.dependency.package.name)` (\(.dependency.package.ecosystem))"' \
+            >> /tmp/security-report.md 2>&1 || echo "_Could not fetch Dependabot alerts (check repo permissions)._" >> /tmp/security-report.md
+
+          # Code scanning alerts
+          echo "" >> /tmp/security-report.md
+          echo "## Code Scanning Alerts" >> /tmp/security-report.md
+          gh api "repos/${REPO}/code-scanning/alerts?state=open&per_page=100" \
+            --jq '.[] | "- **\(.rule.severity // .rule.security_severity_level | ascii_upcase)**: [\(.rule.description)](https://github.com/'"${REPO}"'/security/code-scanning/\(.number)) at `\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)`"' \
+            >> /tmp/security-report.md 2>&1 || echo "_No code scanning alerts or code scanning not enabled._" >> /tmp/security-report.md
+
+          # Secret scanning alerts
+          echo "" >> /tmp/security-report.md
+          echo "## Secret Scanning Alerts" >> /tmp/security-report.md
+          gh api "repos/${REPO}/secret-scanning/alerts?state=open&per_page=100" \
+            --jq '.[] | "- **\(.state | ascii_upcase)**: \(.secret_type_display_name) — [Alert #\(.number)](https://github.com/'"${REPO}"'/security/secret-scanning/\(.number))"' \
+            >> /tmp/security-report.md 2>&1 || echo "_No secret scanning alerts or secret scanning not enabled._" >> /tmp/security-report.md
+
+          # pnpm audit
+          echo "" >> /tmp/security-report.md
+          echo "## pnpm audit" >> /tmp/security-report.md
+          pnpm audit 2>&1 | head -100 >> /tmp/security-report.md || true
+
+          # Socket.dev alerts (from recent open PRs)
+          echo "" >> /tmp/security-report.md
+          echo "## Socket.dev Alerts" >> /tmp/security-report.md
+          # Fetch comments from recent open PRs that contain Socket security reports.
+          # Bot username is "socket-security[bot]" (as of 2025); if Socket changes
+          # their bot name this will silently return no results.
+          SOCKET_FOUND=false
+          for pr_num in $(gh api "repos/${REPO}/pulls?state=open&per_page=5" --jq '.[].number' 2>/dev/null); do
+            SOCKET_COMMENTS=$(gh api "repos/${REPO}/issues/${pr_num}/comments?per_page=30" \
+              --jq '[.[] | select(.user.login == "socket-security[bot]")] | length' \
+              2>/dev/null || echo "0")
+            if [ "$SOCKET_COMMENTS" != "0" ]; then
+              SOCKET_FOUND=true
+              echo "### PR #${pr_num}" >> /tmp/security-report.md
+              gh api "repos/${REPO}/issues/${pr_num}/comments?per_page=30" \
+                --jq '.[] | select(.user.login == "socket-security[bot]") | .body' \
+                2>/dev/null >> /tmp/security-report.md || true
+              echo "" >> /tmp/security-report.md
+            fi
+          done
+          if [ "$SOCKET_FOUND" = "false" ]; then
+            echo "_No Socket.dev alerts found in recent open PRs._" >> /tmp/security-report.md
+          fi
+
+          cat /tmp/security-report.md
+
+          # Export for next step
+          {
+            echo "SECURITY_REPORT<<REPORT_EOF"
+            head -c 50000 /tmp/security-report.md
+            echo ""
+            echo "REPORT_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Triage and fix with Claude
+        id: triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Follow the instructions in .github/prompts/security-vulnerability-scan.md — it is the single source of truth for this job.
+
+            Existing security PR branch: ${{ steps.existing-pr.outputs.exists == 'true' && steps.existing-pr.outputs.branch || 'none (create a new one)' }}
+            If an existing branch is shown above, you are already checked out on it.
+
+            Open dependabot PRs to subsume:
+            ```
+            ${{ env.DEPENDABOT_PRS }}
+            ```
+
+            Raw security data from GitHub APIs and pnpm audit:
+            ```
+            ${{ env.SECURITY_REPORT }}
+            ```
+          claude_args: "--allowedTools Bash Read Write Edit Glob Grep"


### PR DESCRIPTION
## Summary

Introduces an automated weekly security vulnerability scanning and remediation workflow that consolidates security alerts from multiple sources (Dependabot, code scanning, secret scanning, pnpm audit, Socket.dev) and uses Claude to triage, fix, and subsume open dependabot PRs into a single rollup PR.

## Key Changes

- **New GitHub Actions workflow** (`.github/workflows/security-vulnerability-scan.yaml`):
  - Runs weekly on Mondays at 9am UTC (configurable via `workflow_dispatch`)
  - Checks for existing security PR branches and merges them with the default branch
  - Collects open dependabot PRs for subsumption
  - Fetches security alerts from GitHub APIs (Dependabot, code scanning, secret scanning)
  - Runs `pnpm audit` for JavaScript/TypeScript dependencies
  - Extracts Socket.dev alerts from recent open PRs
  - Passes consolidated security report and dependabot PR list to Claude for triage and remediation
  - Uses `anthropics/claude-code-action` with Bash, Read, Write, Edit, and Glob tools

- **New Claude prompt** (`.github/prompts/security-vulnerability-scan.md`):
  - Defines triage criteria (exploitability, severity context, actionability, duplicates)
  - Instructs Claude on applying fixes for dependencies (pnpm, uv) and code vulnerabilities
  - Details the process for subsuming dependabot PRs into the security branch
  - Provides guidance on handling CI failures and deferred issues
  - Specifies PR creation/update procedures with proper formatting and labeling

## Notable Implementation Details

- Uses `PUSH_TOKEN` with fallback to `GITHUB_TOKEN` for security API access (Dependabot and secret scanning require elevated permissions)
- Implements concurrency control to prevent multiple runs from conflicting
- Handles merge conflicts gracefully by aborting if the existing security branch conflicts with the default branch
- Limits security report to first 50KB to avoid token limits in Claude prompts
- Pairs with existing `dependabot-auto-merge.yaml` workflow — this handles complex security work while the other handles routine minor/patch bumps
- Includes safeguards against including AI tool attribution links in PR bodies

https://claude.ai/code/session_01Je3u3ueRrz8Y8AuA1j6hrZ