### PR TITLE
Add markdown-block skill documentation

### DIFF
--- a/.claude/skills/markdown-block/SKILL.md
+++ b/.claude/skills/markdown-block/SKILL.md
@@ -1,0 +1,57 @@
+---
+# prettier-ignore
+name: markdown-block
+description: >
+  Outputs content inside a copyable fenced markdown code block so the user can copy
+  the raw markdown verbatim. Activate whenever the user asks for "copyable markdown",
+  "raw markdown", "the markdown source", "give me the markdown", "as a code block I can
+  copy", or any variation of requesting markdown they can paste elsewhere (READMEs, docs,
+  issues, PR descriptions, chat messages).
+---
+
+# Markdown Block Skill
+
+Wrap the markdown you want the user to copy in a single fenced code block tagged
+`markdown`. The user will see the raw source and can copy it with one click.
+
+## Fence rules — escape inner code blocks
+
+Triple-backtick fences cannot nest. If the markdown contains its own fenced code
+blocks, the inner fences will prematurely close the outer fence and break the
+copy block.
+
+**Rule:** the outer fence must use **strictly more backticks** than the longest
+backtick run anywhere inside the content.
+
+| Inner content contains | Outer fence to use |
+| ---------------------- | ------------------ |
+| no backtick fences     | ` ``` `            |
+| ` ``` ` (3 backticks)  | ` ` ````           |
+| ` ` ```` (4 backticks) | ` ` `````          |
+
+Always scan the content first, find the longest backtick run, then add at least
+one more backtick to the outer fence.
+
+## Example
+
+User asks: "Give me a copyable markdown snippet for a README install section."
+
+Respond with a 4-backtick fence because the inner content has a 3-backtick block:
+
+````markdown
+# Install
+
+Run the following:
+
+```bash
+pnpm install
+```
+````
+
+## Other escaping notes
+
+- Tildes (`~~~`) are an alternate fence — apply the same "more than the longest
+  inner run" rule if you choose tildes instead of backticks.
+- Indented (4-space) code blocks inside the markdown need no escaping.
+- Do not add commentary inside the fence. Put any explanation outside the block
+  so the user copies clean markdown.


### PR DESCRIPTION
## Summary
Added a new skill documentation file that defines how to properly output copyable markdown content for users. This skill enables Claude to wrap markdown in properly-escaped fenced code blocks so users can easily copy raw markdown source.

## Changes
- Created `.claude/skills/markdown-block/SKILL.md` with comprehensive documentation for the markdown-block skill
- Documented the skill's purpose: outputting markdown in copyable fenced code blocks when users request "copyable markdown", "raw markdown", or similar variations
- Included detailed fence escaping rules to handle nested code blocks by using more backticks in the outer fence than any inner fence
- Provided a reference table showing which outer fence to use based on inner content
- Added a practical example demonstrating the skill in action
- Documented alternative escaping approaches (tildes, indented code blocks) and guidelines for clean output

## Implementation Details
The skill documentation emphasizes the critical escaping rule: the outer fence must use strictly more backticks than the longest backtick run in the inner content to prevent premature fence closure. This ensures users receive properly formatted, copyable markdown without syntax errors.

https://claude.ai/code/session_01RZLpjNdikKYCbubXJS3juk