### PR TITLE
ci: Restrict Dependabot to security updates and explicit npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
+
+# Only track a handful of npm packages for version updates.
+# Security updates for all packages are handled separately by
+# GitHub's Dependabot security alerts (enabled at the repo level).
+#
+# "Watch everything" generates weekly churn that maintainers tend to
+# rubber-stamp, undermining the security goal. Default to security-only
+# monitoring with explicit opt-in for packages you actively care about.
+
 updates:
-  # npm/pnpm ecosystem
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     versioning-strategy: auto
-
-  # Python uv ecosystem (if using uv.lock)
-  # Uncomment if you use Python with uv
-  # - package-ecosystem: "uv"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #   versioning-strategy: auto
-
-  # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+    allow:
+      - dependency-name: "punctilio"
+    groups:
+      npm-tracked:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     versioning-strategy: auto
     allow:
       - dependency-name: "punctilio"


### PR DESCRIPTION
## Summary

Refactored Dependabot configuration to reduce maintenance churn by limiting version update tracking to explicitly opted-in npm packages, while relying on GitHub's security alerts for all packages.

## Changes

- **Removed GitHub Actions tracking**: Disabled automatic version updates for `github-actions` ecosystem to reduce weekly churn
- **Removed Python uv configuration**: Deleted commented-out `uv` ecosystem block (not in use)
- **Added npm allowlist**: Introduced `allow` rule to track only the `punctilio` package for version updates
- **Added npm grouping**: Configured `npm-tracked` group to organize allowed dependencies
- **Clarified intent**: Added detailed comments explaining the philosophy: security updates are handled by GitHub's Dependabot alerts, while version churn is minimized through explicit opt-in

## Rationale

This change implements a "security-first, opt-in" approach to dependency management. Automatic version tracking for all packages generates weekly PRs that maintainers tend to rubber-stamp, which undermines the actual security goal. By restricting to security alerts (enabled at repo level) and explicit opt-in for actively maintained packages, the signal-to-noise ratio improves and security updates remain the focus.

https://claude.ai/code/session_01Uq4jYxsqSES8U1AuFcg5E8