### PR TITLE
Harden installer scripts with HTTPS-only, shebang validation, and version pinning

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -59,8 +59,8 @@ Edit `hooks/session-setup.sh` to add more tools:
 # Via uv
 uv_install_if_missing mycommand mypackage
 
-# Via webi (https://webinstall.dev)
-webi_install_if_missing mytool
+# Via webi (https://webinstall.dev) — pin versions for supply-chain safety
+webi_install_if_missing mytool mytool@1
 
 # Via apt (requires root)
 if is_root; then

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -26,14 +26,19 @@ uv_install_if_missing() {
 }
 
 # Install a command via webi if missing
-# Downloads the installer to a temp file first (avoid piping curl to sh directly)
+# $1 = command name, $2 = optional webi package specifier (e.g. tool@version)
+# Hardened: HTTPS-only, shebang validation, version pinning via $2
 webi_install_if_missing() {
-  local cmd="$1"
+  local cmd="$1" pkg="${2:-$1}"
   if ! command -v "$cmd" &>/dev/null; then
     local installer
     installer=$(mktemp "${TMPDIR:-/tmp}/webi-${cmd}-XXXXXX.sh")
-    if curl -fsSL "https://webi.sh/$cmd" -o "$installer" 2>/dev/null; then
-      sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"
+    if curl --proto '=https' -fsSL "https://webi.sh/$pkg" -o "$installer" 2>/dev/null; then
+      if head -n 1 "$installer" | grep -q '^#!'; then
+        sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"
+      else
+        warn "Installer for $cmd is not a shell script (missing shebang) — skipping"
+      fi
     else
       warn "Failed to download installer for $cmd"
     fi
@@ -54,10 +59,10 @@ fi
 # Tool installation (optional - warn on failure)
 #######################################
 
-# Install tools quietly — only warn on failure
-webi_install_if_missing shfmt
-webi_install_if_missing gh
-webi_install_if_missing jq
+# Install tools quietly — only warn on failure (versions pinned for supply-chain safety)
+webi_install_if_missing shfmt shfmt@3
+webi_install_if_missing gh gh@2
+webi_install_if_missing jq jq@1.7
 if ! command -v shellcheck &>/dev/null && is_root; then
   { apt-get update -qq && apt-get install -y -qq shellcheck; } || warn "Failed to install shellcheck"
 fi

--- a/.github/scripts/check-token-scope.sh
+++ b/.github/scripts/check-token-scope.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # Capture stderr so a network error gets surfaced instead of silently producing
 # an empty $HEADERS (which would misclassify a classic PAT as fine-grained).
-if ! HEADERS=$(curl -sSf -I -H "Authorization: token $TOKEN" \
+if ! HEADERS=$(curl --proto '=https' -sSf -I -H "Authorization: token $TOKEN" \
   https://api.github.com/user 2>&1); then
   echo "::error::Could not query GitHub to validate TEMPLATE_SYNC_TOKEN scopes:" >&2
   echo "$HEADERS" >&2


### PR DESCRIPTION
## Summary
Strengthens supply-chain security in the session setup and CI scripts by enforcing HTTPS-only downloads, validating installer shebangs before execution, and pinning tool versions.

## Changes
- **`webi_install_if_missing()` hardening**:
  - Added `--proto '=https'` to curl to reject non-HTTPS redirects
  - Introduced optional `$2` parameter for version pinning (e.g., `webi_install_if_missing jq jq@1.7`)
  - Added shebang validation: checks that downloaded installers start with `#!` before executing, warns and skips if missing
  - Updated function documentation to reflect security posture

- **Tool installation updates**:
  - Pinned versions for `shfmt@3`, `gh@2`, `jq@1.7` to reduce supply-chain attack surface
  - Updated README to document version-pinning pattern for webi installations

- **CI script hardening**:
  - Applied `--proto '=https'` to `check-token-scope.sh` curl invocation for consistency

## Implementation Details
- Shebang validation uses `head -n 1 | grep -q '^#!'` to detect shell scripts before execution
- Version pinning is optional (defaults to command name if `$2` omitted) for backward compatibility
- All changes maintain existing error handling and warning behavior

https://claude.ai/code/session_01JdwqaLpVxCJPKynqypt39D