### PR TITLE
Support per-file excludes in template sync

### DIFF
--- a/.github/scripts/request-claude-resolve.sh
+++ b/.github/scripts/request-claude-resolve.sh
@@ -17,7 +17,9 @@ HAS_DELETIONS="${HAS_DELETIONS:-false}"
 CONFLICT_FILES="${CONFLICT_FILES:-}"
 DELETED_FILES="${DELETED_FILES:-}"
 
-BODY="@claude Resolve this template sync PR so it's ready to merge."
+BODY="@claude Resolve this template sync PR so it's ready to merge.
+
+**Important:** Check whether newly added workflow files duplicate CI that the target repo already has (e.g., the repo may already have its own test or lint workflows under different names or configurations). If a synced workflow (like \`node-tests.yaml\`, \`lint.yaml\`, \`format-check.yaml\`) duplicates existing CI, delete the redundant template workflow and add its path to EXCLUDE_PATHS in \`template-sync.yaml\` so it won't be re-added on future syncs."
 
 if [ "$HAS_CONFLICTS" = "true" ]; then
   BODY="$BODY

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -5,7 +5,8 @@
 # Inputs (env):
 #   SYNC_PATHS        Space-separated paths to sync from the template
 #                     (path names containing spaces are NOT supported)
-#   EXCLUDE_PATHS     Space-separated paths to exclude (subset of SYNC_PATHS)
+#   EXCLUDE_PATHS     Space-separated paths to exclude (whole SYNC_PATHS entries
+#                     or individual file paths within synced directories)
 #   GITHUB_OUTPUT     Path to GitHub Actions output file
 #
 # Assumes a sibling `_template/` directory containing a checkout of the
@@ -248,6 +249,7 @@ for path in $SYNC_PATHS; do
   if [ -n "$PREV_SHA" ]; then
     while IFS= read -r prev_file; do
       case "$prev_file" in "$path" | "$path/"*) ;; *) continue ;; esac
+      is_excluded "$prev_file" && continue
       if [ ! -f "_template/$prev_file" ]; then
         echo "DELETED in template: $prev_file"
         echo "$prev_file" >>"$DELETED_FILES"
@@ -263,6 +265,7 @@ for path in $SYNC_PATHS; do
   if [ -d "_template/$path" ]; then
     while IFS= read -r template_file; do
       rel_path="${template_file#_template/}"
+      is_excluded "$rel_path" && continue
       process_file "$rel_path"
     done < <(find "_template/$path" -type f)
   else

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -21,6 +21,9 @@ name: Sync from Template
 #    customizations" or "Future Claudes: Leave these customizations as-is"
 # 2. Preserve local customizations while adopting new template features
 # 3. When in doubt, keep local changes - they exist for a reason
+# 4. Check for duplicate CI: if the target repo already has test/lint/format
+#    workflows, don't add the template's versions — exclude them via
+#    EXCLUDE_PATHS instead
 # =============================================================================
 
 on:
@@ -43,9 +46,13 @@ env:
   # Downstream-added files in these directories are left alone (sync only
   # copies files that exist in the template).
   SYNC_PATHS: ".claude .hooks .github/actions .github/scripts .github/workflows .github/prompts"
-  # Paths listed here are removed from SYNC_PATHS before processing. Match is
-  # exact-string against entries in SYNC_PATHS (whole directories). Per-file
-  # excludes inside a synced directory are not supported.
+  # Paths to exclude from syncing. Supports both whole directories (matching
+  # entries in SYNC_PATHS) and individual files within synced directories.
+  #
+  # NOTE: If the target repo already has its own test/lint/format CI workflows,
+  # exclude the template's equivalents here to avoid duplicate CI jobs.
+  # Common candidates: .github/workflows/node-tests.yaml,
+  # .github/workflows/lint.yaml, .github/workflows/format-check.yaml
   EXCLUDE_PATHS: ""
 
 permissions:

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -262,6 +262,52 @@ def test_excluded_paths_are_not_synced(workdir: Path) -> None:
     assert not (child / "other" / "b.txt").exists()
 
 
+def test_per_file_excludes_within_synced_directory(workdir: Path) -> None:
+    """Individual files within a synced directory can be excluded."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "keep.txt", "keep this\n")
+    write(template / "config" / "skip.txt", "skip this\n")
+    commit_all(template)
+
+    result, output_file = run_sync(
+        child,
+        template,
+        sync_paths="config",
+        exclude_paths="config/skip.txt",
+    )
+    assert result.returncode == 0, result.stderr
+
+    assert (child / "config" / "keep.txt").read_text() == "keep this\n"
+    assert not (child / "config" / "skip.txt").exists()
+
+
+def test_per_file_exclude_suppresses_deletion_report(workdir: Path) -> None:
+    """Files excluded by EXCLUDE_PATHS should not be reported as deleted."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "x\n")
+    write(template / "config" / "b.txt", "y\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "a.txt", "x\n")
+    write(child / "config" / "b.txt", "y\n")
+    (child / ".template-version").write_text(prev_sha)
+    commit_all(child)
+    (template / "config" / "b.txt").unlink()
+    commit_all(template)
+
+    result, output_file = run_sync(
+        child,
+        template,
+        sync_paths="config",
+        exclude_paths="config/b.txt",
+    )
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["has_deletions"] == "false"
+
+
 def test_writes_template_version_with_trailing_newline(workdir: Path) -> None:
     """The .template-version file MUST end with a trailing newline; the
     `test_no_changes_when_files_identical` invariant depends on it."""


### PR DESCRIPTION
## Summary

Extends the template sync mechanism to support excluding individual files within synced directories, not just whole directories. This enables downstream repos to exclude specific template files (e.g., duplicate CI workflows) while keeping others in the same directory.

## Changes

- **Test coverage**: Added two new tests:
  - `test_per_file_excludes_within_synced_directory`: Verifies that individual files can be excluded from a synced directory
  - `test_per_file_exclude_suppresses_deletion_report`: Ensures excluded files don't trigger false deletion reports when removed from the template

- **Sync script logic** (`.github/scripts/template-sync.sh`):
  - Added `is_excluded` check when processing previously-synced files to prevent false deletion reports for excluded files
  - Added `is_excluded` check when processing template files to skip excluded files during sync
  - Updated documentation to clarify that `EXCLUDE_PATHS` now supports both whole directories and individual file paths

- **Workflow documentation** (`.github/workflows/template-sync.yaml`):
  - Added guidance comment about checking for duplicate CI workflows
  - Enhanced `EXCLUDE_PATHS` documentation with examples of common candidates to exclude (node-tests.yaml, lint.yaml, format-check.yaml)

- **Claude request script** (`.github/scripts/request-claude-resolve.sh`):
  - Added instructions to the Claude request body to check for and handle duplicate CI workflows by excluding them via `EXCLUDE_PATHS`

## Implementation Details

The per-file exclude feature works by checking each file path against `EXCLUDE_PATHS` before processing, supporting both exact directory matches (existing behavior) and individual file paths within synced directories (new behavior). This prevents excluded files from being synced, deleted, or reported as deletions.

https://claude.ai/code/session_01DkF4o9b4L1e4UhYYWdXRZo