### PR TITLE
Auto-configure Claude Code permissions in web sessions

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -122,7 +122,7 @@ remote_url="${remote_url:-$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/n
 if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
   local_settings="$PROJECT_DIR/.claude/settings.local.json"
   if [ ! -f "$local_settings" ]; then
-    cat > "$local_settings" <<'SETTINGS'
+    cat >"$local_settings" <<'SETTINGS'
 {
   "permissions": {
     "allow": [

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -113,6 +113,30 @@ if [ -z "${GH_REPO:-}" ]; then
 fi
 
 #######################################
+# Web-session permissions
+#######################################
+
+# In web sessions (detected by proxy remote URL), grant Claude Code
+# permission to modify its own .claude/ folder without prompting.
+remote_url="${remote_url:-$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null)}"
+if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
+  local_settings="$PROJECT_DIR/.claude/settings.local.json"
+  if [ ! -f "$local_settings" ]; then
+    cat > "$local_settings" <<'SETTINGS'
+{
+  "permissions": {
+    "allow": [
+      "Edit .claude/**",
+      "Write .claude/**",
+      "Read .claude/**"
+    ]
+  }
+}
+SETTINGS
+  fi
+fi
+
+#######################################
 # Project dependencies
 #######################################
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": ["Edit .claude/**", "Write .claude/**", "Read .claude/**"]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "permissions": {
-    "allow": ["Edit .claude/**", "Write .claude/**", "Read .claude/**"]
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ out/
 *.swp
 *.swo
 
+# Claude Code local settings (written by SessionStart hook in web sessions)
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

Automatically grant Claude Code permission to modify the `.claude/` folder in web sessions (detected by proxy remote URL), eliminating permission prompts during session setup.

## Changes

- **`.claude/hooks/session-setup.sh`**: Added web-session detection logic that creates `.claude/settings.local.json` with appropriate permissions when the git remote URL matches the proxy pattern (`127.0.0.1.*/git/`). This allows Claude Code to edit, write, and read `.claude/**` without user prompts.
- **`.gitignore`**: Added `.claude/settings.local.json` to ignore list, since this file is generated dynamically by the SessionStart hook in web sessions and should not be committed.

## Implementation Details

The detection uses a regex match on the git remote origin URL to identify web sessions. The settings file is only created if it doesn't already exist, allowing manual overrides. The permissions granted are scoped to the `.claude/` folder to minimize surface area while enabling necessary self-modification during setup.

## Lessons Learned

**Template repo**: Add web-session permission auto-configuration to the session-setup hook template.
- **What**: Include the web-session detection and `.claude/settings.local.json` generation logic in `.claude/hooks/session-setup.sh`.
- **Where**: `.claude/hooks/session-setup.sh`, after the GH_REPO block and before the "Project dependencies" section.
- **Why**: Web sessions are a common deployment pattern for Claude Code, and auto-configuring permissions eliminates friction during setup while maintaining security by scoping permissions narrowly to the `.claude/` folder. This pattern is reusable across all downstream repos using the template.

Also add `.claude/settings.local.json` to `.gitignore` in the template with a comment explaining it's generated by the SessionStart hook.

https://claude.ai/code/session_01YX4WkXMEPGQUCGUPRofdM9