### PR TITLE
Refactor phone-home workflow: extract scripts, add secret scanning

### DIFF
--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -19,13 +19,13 @@ runs:
   steps:
     - name: Set up Node.js
       if: hashFiles('package.json') != ''
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Install pnpm
       if: hashFiles('package.json') != ''
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
     - name: Get pnpm store directory
       if: hashFiles('package.json') != ''
@@ -35,7 +35,7 @@ runs:
 
     - name: Restore pnpm cache
       if: hashFiles('package.json') != ''
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -49,7 +49,7 @@ runs:
 
     - name: Set up uv
       if: inputs.setup-python == 'true'
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,15 @@ updates:
       npm-tracked:
         patterns:
           - "*"
+
+  # Track GitHub Actions versions — mutable version tags (e.g. @v4) let a
+  # compromised action maintainer silently replace code. Dependabot PRs for
+  # actions surface version changes for review.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,15 +20,3 @@ updates:
       npm-tracked:
         patterns:
           - "*"
-
-  # Track GitHub Actions versions — mutable version tags (e.g. @v4) let a
-  # compromised action maintainer silently replace code. Dependabot PRs for
-  # actions surface version changes for review.
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      actions-all:
-        patterns:
-          - "*"

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -58,7 +58,9 @@ gh_api_section \
 # Skip when there's no Node project — setup-base-env leaves pnpm uninstalled
 # in that case, and `pnpm audit` would error out instead of returning "clean".
 if [ -f package.json ]; then
-  pnpm audit 2>&1 | head -100 >>"$REPORT_PATH" || true
+  pnpm audit 2>&1 | head -100 >>"$REPORT_PATH"; pnpm_rc=${PIPESTATUS[0]}
+  # Exit 0 = clean, exit 1 = vulnerabilities found (expected); higher = real error
+  [ "${pnpm_rc:-0}" -le 1 ] || echo "_pnpm audit encountered an error (exit code $pnpm_rc); output above may be incomplete._" >>"$REPORT_PATH"
 else
   echo "_Skipped: no package.json (not a Node project)._" >>"$REPORT_PATH"
 fi
@@ -94,9 +96,19 @@ fi
 
 cat "$REPORT_PATH"
 
+# Use a random sentinel to prevent delimiter injection — report content comes
+# from external sources (advisory descriptions, bot comments) that an attacker
+# could craft to contain a static sentinel and inject arbitrary env vars.
+if [ -r /proc/sys/kernel/random/uuid ]; then
+  report_sentinel="REPORT_EOF_$(cat /proc/sys/kernel/random/uuid)"
+elif command -v uuidgen >/dev/null 2>&1; then
+  report_sentinel="REPORT_EOF_$(uuidgen)"
+else
+  report_sentinel="REPORT_EOF_$$_${RANDOM}_${RANDOM}"
+fi
 {
-  echo "SECURITY_REPORT<<REPORT_EOF"
+  echo "SECURITY_REPORT<<${report_sentinel}"
   head -c 50000 "$REPORT_PATH"
   echo ""
-  echo "REPORT_EOF"
+  echo "${report_sentinel}"
 } >>"$GITHUB_ENV"

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -58,7 +58,8 @@ gh_api_section \
 # Skip when there's no Node project — setup-base-env leaves pnpm uninstalled
 # in that case, and `pnpm audit` would error out instead of returning "clean".
 if [ -f package.json ]; then
-  pnpm audit 2>&1 | head -100 >>"$REPORT_PATH"; pnpm_rc=${PIPESTATUS[0]}
+  pnpm audit 2>&1 | head -100 >>"$REPORT_PATH"
+  pnpm_rc=${PIPESTATUS[0]}
   # Exit 0 = clean, exit 1 = vulnerabilities found (expected); higher = real error
   [ "${pnpm_rc:-0}" -le 1 ] || echo "_pnpm audit encountered an error (exit code $pnpm_rc); output above may be incomplete._" >>"$REPORT_PATH"
 else

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/.github/scripts/phone-home-extract.js
+++ b/.github/scripts/phone-home-extract.js
@@ -1,0 +1,74 @@
+// @ts-check
+"use strict";
+
+const fs = require("fs");
+
+const MIN_CONTENT_LENGTH = 10;
+const PHONE_HOME_DIR = "/tmp/phone-home";
+
+/**
+ * Extract "Lessons Learned" from a merged PR body, filter noise, and write
+ * the cleaned text to a temp file for gitleaks scanning.
+ *
+ * Called by the phone-home workflow via actions/github-script.
+ *
+ * @param {object}  params
+ * @param {object}  params.context  - GitHub Actions webhook event context
+ * @param {{ setOutput(name: string, value: string): void }} params.core
+ */
+module.exports = async ({ context, core }) => {
+  const prBody = context.payload.pull_request.body || "";
+  const repo = `${context.repo.owner}/${context.repo.repo}`;
+
+  if (repo === process.env.TEMPLATE_REPO) {
+    console.log("This IS the template repo, skipping phone-home");
+    return;
+  }
+
+  const lessonsMatch = prBody.match(
+    /## Lessons Learned\s*\n([\s\S]*?)(?=\n## |\n---|\s*$)/i,
+  );
+  if (!lessonsMatch) {
+    console.log(
+      'No "Lessons Learned" section found in PR body, skipping phone-home',
+    );
+    return;
+  }
+
+  const lessons = lessonsMatch[1].trim();
+  if (!lessons || lessons.length < MIN_CONTENT_LENGTH) {
+    console.log("Lessons section is empty or too short, skipping");
+    return;
+  }
+
+  const filtered = lessons
+    .split("\n")
+    .filter((line) => !line.trim().match(/^<.*>$/))
+    .filter((line) => !line.trim().match(/^<!--.*-->$/))
+    .filter(
+      (line) => !line.trim().match(/^https:\/\/claude\.ai\/code\/session_/),
+    )
+    .filter((line) => !line.trim().match(/^```/))
+    .join("\n")
+    .trim();
+  if (!filtered || filtered.length < MIN_CONTENT_LENGTH) {
+    console.log(
+      "Lessons section only contains template placeholders, skipping",
+    );
+    return;
+  }
+
+  const stripped = filtered.replace(/\*\*(What|Where|Why)\*\*:\s*/g, "").trim();
+  if (!stripped || stripped.length < MIN_CONTENT_LENGTH) {
+    console.log("Lessons section only contains template skeleton, skipping");
+    return;
+  }
+
+  fs.mkdirSync(PHONE_HOME_DIR, { recursive: true });
+  fs.writeFileSync(`${PHONE_HOME_DIR}/lessons.txt`, filtered);
+
+  core.setOutput("has_lessons", "true");
+  core.setOutput("pr_title", context.payload.pull_request.title);
+  core.setOutput("pr_url", context.payload.pull_request.html_url);
+  core.setOutput("source_repo", repo);
+};

--- a/.github/scripts/phone-home-submit.js
+++ b/.github/scripts/phone-home-submit.js
@@ -1,0 +1,68 @@
+// @ts-check
+"use strict";
+
+const fs = require("fs");
+
+const PHONE_HOME_DIR = "/tmp/phone-home";
+
+/**
+ * Submit extracted lessons as an issue on the template repository.
+ *
+ * Called by the phone-home workflow via actions/github-script.
+ * Expects PR_TITLE, PR_URL, SOURCE_REPO, and TEMPLATE_REPO env vars.
+ *
+ * @param {object}  params
+ * @param {{ rest: { issues: { create(p: object): Promise<{data: {html_url: string, number: number}}>; addLabels(p: object): Promise<void> } } }} params.github
+ */
+module.exports = async ({ github }) => {
+  const lessons = fs.readFileSync(`${PHONE_HOME_DIR}/lessons.txt`, "utf8");
+  const prTitle = /** @type {string} */ (process.env.PR_TITLE);
+  const prUrl = /** @type {string} */ (process.env.PR_URL);
+  const repo = /** @type {string} */ (process.env.SOURCE_REPO);
+  const templateRepo = /** @type {string} */ (process.env.TEMPLATE_REPO);
+
+  const issueBody = [
+    `## Improvement Suggestion from \`${repo}\``,
+    "",
+    `**Source PR:** ${prUrl}`,
+    `**PR Title:** ${prTitle}`,
+    "",
+    "## Lessons Learned",
+    "",
+    lessons,
+    "",
+    "---",
+    `*Automatically submitted by the phone-home workflow from \`${repo}\`.*`,
+  ].join("\n");
+
+  const [templateOwner, templateRepoName] = templateRepo.split("/");
+  let issue;
+  try {
+    issue = await github.rest.issues.create({
+      owner: templateOwner,
+      repo: templateRepoName,
+      title: `[phone-home] ${prTitle}`,
+      body: issueBody,
+    });
+    console.log(`Created issue on template repo: ${issue.data.html_url}`);
+  } catch (error) {
+    console.log(`Could not create issue on ${templateRepo}: ${error.message}`);
+    console.log("This is expected if TEMPLATE_SYNC_TOKEN is not configured.");
+    console.log("To enable phone-home, add a TEMPLATE_SYNC_TOKEN secret with");
+    console.log("permission to create issues on the template repository.");
+    return;
+  }
+
+  try {
+    await github.rest.issues.addLabels({
+      owner: templateOwner,
+      repo: templateRepoName,
+      issue_number: issue.data.number,
+      labels: ["phone-home", "triage"],
+    });
+  } catch (labelError) {
+    console.log(
+      `Could not add labels (they may not exist yet): ${labelError.message}`,
+    );
+  }
+};

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -31,11 +31,11 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -12,7 +12,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,21 @@
+name: Gitleaks Secret Scanning
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -26,7 +26,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -22,17 +22,21 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'phone-home')
     runs-on: ubuntu-latest
     steps:
-      - name: Extract and submit improvements
-        env:
-          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
-        uses: actions/github-script@v9
+      - name: Extract lessons from PR body
+        id: extract
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          github-token: ${{ env.GH_TOKEN }}
           script: |
+            const fs = require('fs');
             const prBody = context.payload.pull_request.body || '';
-            const prTitle = context.payload.pull_request.title;
-            const prUrl = context.payload.pull_request.html_url;
             const repo = `${context.repo.owner}/${context.repo.repo}`;
+
+            // Skip if this is the template repo itself
+            const templateRepo = process.env.TEMPLATE_REPO;
+            if (repo === templateRepo) {
+              console.log('This IS the template repo, skipping phone-home');
+              return;
+            }
 
             // Extract "Lessons Learned" section from PR body
             const lessonsMatch = prBody.match(/## Lessons Learned\s*\n([\s\S]*?)(?=\n## |\n---|\s*$)/i);
@@ -72,38 +76,42 @@ jobs:
               return;
             }
 
-            // Reject if content contains patterns that look like secrets —
-            // prevents accidental credential leakage to the template repo.
-            const secretPatterns = [
-              /(?:api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token|secret[_-]?key)\s*[:=]\s*\S+/i,
-              /\b(?:sk|pk|rk)[-_](?:live|test|prod)[a-zA-Z0-9_-]{10,}\b/,
-              /\bghp_[a-zA-Z0-9]{36,}\b/,
-              /\bgho_[a-zA-Z0-9]{36,}\b/,
-              /\bghu_[a-zA-Z0-9]{36,}\b/,
-              /\bghs_[a-zA-Z0-9]{36,}\b/,
-              /\bghr_[a-zA-Z0-9]{36,}\b/,
-              /\bAKIA[0-9A-Z]{16}\b/,
-              /\bAIza[0-9A-Za-z_-]{35}\b/,
-              /\bxox[bporas]-[a-zA-Z0-9-]{10,}\b/,
-              /-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----/,
-            ];
-            for (const pattern of secretPatterns) {
-              if (pattern.test(filtered)) {
-                console.log(`Lessons section appears to contain a secret (matched ${pattern}), refusing to phone home`);
-                return;
-              }
-            }
+            // Write lessons to a temp file for gitleaks scanning
+            fs.mkdirSync('/tmp/phone-home', { recursive: true });
+            fs.writeFileSync('/tmp/phone-home/lessons.txt', filtered);
 
-            lessons = filtered;
+            core.setOutput('has_lessons', 'true');
+            core.setOutput('pr_title', context.payload.pull_request.title);
+            core.setOutput('pr_url', context.payload.pull_request.html_url);
+            core.setOutput('source_repo', repo);
 
-            // Check if this is about the template itself (skip to avoid self-referential issues)
-            const templateRepo = process.env.TEMPLATE_REPO;
-            if (repo === templateRepo) {
-              console.log('This IS the template repo, skipping phone-home');
-              return;
-            }
+      - name: Scan lessons for leaked secrets
+        if: steps.extract.outputs.has_lessons == 'true'
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl --proto '=https' -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar xz -C /usr/local/bin gitleaks
+          gitleaks detect --no-git -s /tmp/phone-home -v
 
-            // Build the issue body
+      - name: Submit to template repo
+        if: steps.extract.outputs.has_lessons == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ steps.extract.outputs.pr_title }}
+          PR_URL: ${{ steps.extract.outputs.pr_url }}
+          SOURCE_REPO: ${{ steps.extract.outputs.source_repo }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const lessons = fs.readFileSync('/tmp/phone-home/lessons.txt', 'utf8');
+            const prTitle = process.env.PR_TITLE;
+            const prUrl = process.env.PR_URL;
+            const repo = process.env.SOURCE_REPO;
+
             const issueBody = [
               `## Improvement Suggestion from \`${repo}\``,
               '',
@@ -118,8 +126,7 @@ jobs:
               `*Automatically submitted by the phone-home workflow from \`${repo}\`.*`,
             ].join('\n');
 
-            // Open an issue on the template repo (without labels first, then add them separately)
-            const [templateOwner, templateRepoName] = templateRepo.split('/');
+            const [templateOwner, templateRepoName] = process.env.TEMPLATE_REPO.split('/');
             let issue;
             try {
               issue = await github.rest.issues.create({
@@ -130,16 +137,13 @@ jobs:
               });
               console.log(`Created issue on template repo: ${issue.data.html_url}`);
             } catch (error) {
-              // If we don't have permission to create issues on the template repo,
-              // log it but don't fail the workflow
-              console.log(`Could not create issue on ${templateRepo}: ${error.message}`);
+              console.log(`Could not create issue on ${process.env.TEMPLATE_REPO}: ${error.message}`);
               console.log('This is expected if TEMPLATE_SYNC_TOKEN is not configured.');
               console.log('To enable phone-home, add a TEMPLATE_SYNC_TOKEN secret with');
               console.log('permission to create issues on the template repository.');
               return;
             }
 
-            // Try to add labels separately — if they don't exist, the issue is still created
             try {
               await github.rest.issues.addLabels({
                 owner: templateOwner,

--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -71,6 +71,29 @@ jobs:
               console.log('Lessons section only contains template skeleton, skipping');
               return;
             }
+
+            // Reject if content contains patterns that look like secrets —
+            // prevents accidental credential leakage to the template repo.
+            const secretPatterns = [
+              /(?:api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token|secret[_-]?key)\s*[:=]\s*\S+/i,
+              /\b(?:sk|pk|rk)[-_](?:live|test|prod)[a-zA-Z0-9_-]{10,}\b/,
+              /\bghp_[a-zA-Z0-9]{36,}\b/,
+              /\bgho_[a-zA-Z0-9]{36,}\b/,
+              /\bghu_[a-zA-Z0-9]{36,}\b/,
+              /\bghs_[a-zA-Z0-9]{36,}\b/,
+              /\bghr_[a-zA-Z0-9]{36,}\b/,
+              /\bAKIA[0-9A-Z]{16}\b/,
+              /\bAIza[0-9A-Za-z_-]{35}\b/,
+              /\bxox[bporas]-[a-zA-Z0-9-]{10,}\b/,
+              /-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----/,
+            ];
+            for (const pattern of secretPatterns) {
+              if (pattern.test(filtered)) {
+                console.log(`Lessons section appears to contain a secret (matched ${pattern}), refusing to phone home`);
+                return;
+              }
+            }
+
             lessons = filtered;
 
             // Check if this is about the template itself (skip to avoid self-referential issues)

--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -22,68 +22,17 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'phone-home')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/scripts
+
       - name: Extract lessons from PR body
         id: extract
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const fs = require('fs');
-            const prBody = context.payload.pull_request.body || '';
-            const repo = `${context.repo.owner}/${context.repo.repo}`;
-
-            // Skip if this is the template repo itself
-            const templateRepo = process.env.TEMPLATE_REPO;
-            if (repo === templateRepo) {
-              console.log('This IS the template repo, skipping phone-home');
-              return;
-            }
-
-            // Extract "Lessons Learned" section from PR body
-            const lessonsMatch = prBody.match(/## Lessons Learned\s*\n([\s\S]*?)(?=\n## |\n---|\s*$)/i);
-            if (!lessonsMatch) {
-              console.log('No "Lessons Learned" section found in PR body, skipping phone-home');
-              return;
-            }
-
-            let lessons = lessonsMatch[1].trim();
-            if (!lessons || lessons.length < 10) {
-              console.log('Lessons section is empty or too short, skipping');
-              return;
-            }
-
-            // Filter out template placeholders, HTML comments, session URLs,
-            // and code fences. The heredoc-artifact patterns (EOF, closing paren)
-            // were so narrow they only matched a handful of specific heredoc styles
-            // while missing all others, so they provided no real protection and
-            // have been removed.
-            const filtered = lessons
-              .split('\n')
-              .filter(line => !line.trim().match(/^<.*>$/))
-              .filter(line => !line.trim().match(/^<!--.*-->$/))
-              .filter(line => !line.trim().match(/^https:\/\/claude\.ai\/code\/session_/))
-              .filter(line => !line.trim().match(/^```/))
-              .join('\n')
-              .trim();
-            if (!filtered || filtered.length < 10) {
-              console.log('Lessons section only contains template placeholders, skipping');
-              return;
-            }
-
-            // Reject if content is just the template's What/Where/Why skeleton
-            const stripped = filtered.replace(/\*\*(What|Where|Why)\*\*:\s*/g, '').trim();
-            if (!stripped || stripped.length < 10) {
-              console.log('Lessons section only contains template skeleton, skipping');
-              return;
-            }
-
-            // Write lessons to a temp file for gitleaks scanning
-            fs.mkdirSync('/tmp/phone-home', { recursive: true });
-            fs.writeFileSync('/tmp/phone-home/lessons.txt', filtered);
-
-            core.setOutput('has_lessons', 'true');
-            core.setOutput('pr_title', context.payload.pull_request.title);
-            core.setOutput('pr_url', context.payload.pull_request.html_url);
-            core.setOutput('source_repo', repo);
+            const run = require('./.github/scripts/phone-home-extract.js')
+            await run({github, context, core})
 
       - name: Scan lessons for leaked secrets
         if: steps.extract.outputs.has_lessons == 'true'
@@ -106,51 +55,5 @@ jobs:
         with:
           github-token: ${{ env.GH_TOKEN }}
           script: |
-            const fs = require('fs');
-            const lessons = fs.readFileSync('/tmp/phone-home/lessons.txt', 'utf8');
-            const prTitle = process.env.PR_TITLE;
-            const prUrl = process.env.PR_URL;
-            const repo = process.env.SOURCE_REPO;
-
-            const issueBody = [
-              `## Improvement Suggestion from \`${repo}\``,
-              '',
-              `**Source PR:** ${prUrl}`,
-              `**PR Title:** ${prTitle}`,
-              '',
-              '## Lessons Learned',
-              '',
-              lessons,
-              '',
-              '---',
-              `*Automatically submitted by the phone-home workflow from \`${repo}\`.*`,
-            ].join('\n');
-
-            const [templateOwner, templateRepoName] = process.env.TEMPLATE_REPO.split('/');
-            let issue;
-            try {
-              issue = await github.rest.issues.create({
-                owner: templateOwner,
-                repo: templateRepoName,
-                title: `[phone-home] ${prTitle}`,
-                body: issueBody,
-              });
-              console.log(`Created issue on template repo: ${issue.data.html_url}`);
-            } catch (error) {
-              console.log(`Could not create issue on ${process.env.TEMPLATE_REPO}: ${error.message}`);
-              console.log('This is expected if TEMPLATE_SYNC_TOKEN is not configured.');
-              console.log('To enable phone-home, add a TEMPLATE_SYNC_TOKEN secret with');
-              console.log('permission to create issues on the template repository.');
-              return;
-            }
-
-            try {
-              await github.rest.issues.addLabels({
-                owner: templateOwner,
-                repo: templateRepoName,
-                issue_number: issue.data.number,
-                labels: ['phone-home', 'triage'],
-              });
-            } catch (labelError) {
-              console.log(`Could not add labels (they may not exist yet): ${labelError.message}`);
-            }
+            const run = require('./.github/scripts/phone-home-submit.js')
+            await run({github, context, core})

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,8 +12,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
@@ -64,7 +64,7 @@ jobs:
 
       - name: Triage and fix with Claude
         id: triage
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -81,14 +81,17 @@ jobs:
       - name: Check token workflow scope
         env:
           TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
-        run: bash _template/.github/scripts/check-token-scope.sh
+        # Run the child repo's own copy — never execute scripts directly from
+        # the template checkout. Template script updates arrive via sync PRs
+        # and go through human review before they can execute.
+        run: bash .github/scripts/check-token-scope.sh
 
       - name: Sync template files with conflict detection
         id: sync
         env:
           SYNC_PATHS: ${{ env.SYNC_PATHS }}
           EXCLUDE_PATHS: ${{ env.EXCLUDE_PATHS }}
-        run: bash _template/.github/scripts/template-sync.sh
+        run: bash .github/scripts/template-sync.sh
 
       - name: Show diff (dry run)
         if: inputs.dry-run == 'true' && steps.sync.outputs.has_changes == 'true'

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -64,13 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout child repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           filter: blob:none
 
       - name: Checkout template repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: ${{ env.TEMPLATE_REPO }}
           path: _template
@@ -105,7 +105,7 @@ jobs:
       - name: Create Pull Request
         if: inputs.dry-run != 'true' && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync from template repository (${{ steps.sync.outputs.template_sha_short }})"

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -23,7 +23,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 pas
 
 ## CI / GitHub Actions
 
+- **Extract significant inline scripts** from workflow YAML into standalone files under `.github/scripts/` so they can be linted, type-checked, and tested independently. Inline scripts in `run:` or `script:` blocks are invisible to linters, shellcheck, `@ts-check`, and test frameworks. Rule of thumb: if the inline block exceeds ~10 lines or contains branching logic, extract it. Shell scripts go in `.github/scripts/*.sh`; JS scripts used by `actions/github-script` go in `.github/scripts/*.js` (with `@ts-check` and JSDoc types) and are loaded via `require('./.github/scripts/foo.js')`. Keep trivial glue (single commands, simple output-setting) inline.
+- **Pin all third-party GitHub Actions to commit SHAs** (with a `# vX.Y` comment). Mutable version tags let a compromised maintainer silently replace code. Example: `uses: actions/checkout@de0fac2...dd # v6`.
 - Add the `ci:full-tests` label to PRs that modify Playwright tests or interaction behavior, so CI actually runs Playwright on the PR.
 - **`paths` filter pitfall**: if a workflow uses `paths` on one trigger (e.g., `push`) but not the other (e.g., `pull_request`), the triggers fire on different sets of changes, leading to confusing behavior. Always keep `paths` filters consistent across both `push` and `pull_request` triggers.
 - **Autofix workflow pitfalls**: When building a workflow that auto-fixes CI failures:


### PR DESCRIPTION
## Summary

Refactored the `phone-home` workflow to improve maintainability, security, and auditability by extracting inline scripts into standalone modules and adding gitleaks secret scanning before submission to the template repo.

## Key Changes

- **Extracted phone-home logic into modular scripts**:
  - `.github/scripts/phone-home-extract.js`: Parses PR body, extracts "Lessons Learned" section, filters noise, and writes cleaned content to `/tmp/phone-home/lessons.txt` for scanning
  - `.github/scripts/phone-home-submit.js`: Reads scanned lessons and submits them as an issue on the template repo
  - Both scripts are now lintable, type-checkable, and testable as standalone modules

- **Added secret scanning step**: Integrated gitleaks (v8.30.1) to scan extracted lessons for leaked credentials before submission, preventing accidental exposure of secrets in the template repo

- **Improved workflow structure**:
  - Separated extraction, scanning, and submission into distinct steps with clear conditional gates
  - Extraction outputs are passed to downstream steps via GitHub Actions outputs
  - Scanning only runs if lessons were successfully extracted (`has_lessons == 'true'`)
  - Submission only runs after scanning passes

- **Added gitleaks standalone workflow** (`.github/workflows/gitleaks.yaml`): Runs on push to main and all PRs to catch secrets in the repository itself

- **Fixed security issue in `fetch-security-report.sh`**:
  - Replaced unsafe `|| true` with proper exit code branching to avoid silently swallowing real errors from `pnpm audit`
  - Added random UUID-based sentinel for heredoc delimiter to prevent injection attacks from external advisory content

- **Pinned all GitHub Actions to commit SHAs** across workflows for supply-chain security:
  - `actions/checkout`, `actions/setup-node`, `actions/setup-python`, `actions/cache/restore`, `pnpm/action-setup`, `astral-sh/setup-uv`, `pre-commit/action`, `anthropics/claude-code-action`, `dependabot/fetch-metadata`, `gitleaks/gitleaks-action`

- **Fixed template-sync workflow security**: Changed to execute scripts from the child repo's own `.github/scripts/` instead of the template checkout, preventing execution of untrusted template updates before human review

- **Added `.github/scripts/package.json`**: Declares CommonJS module type for Node.js scripts

## Implementation Details

- Extraction script validates content length at each filtering stage to avoid submitting empty or template-only lessons
- Submission script reads the pre-scanned lessons file, ensuring only gitleaks-approved content reaches the template repo
- Both scripts use JSDoc type annotations for clarity and IDE support
- Gitleaks scanning runs with `--no-git` flag (scanning only the extracted file, not the full repo history)
- Random sentinel generation handles systems with and without `/proc/sys/kernel/random/uuid` or `uuidgen`

## Lessons Learned

**What**: Extract significant inline scripts from workflow YAML into standalone `.github/scripts/` files.

**Where**: Apply to all workflows with non-trivial logic (>20 lines of script content), particularly those handling sensitive data like the phone-home and security-report workflows.

**Why**: Standalone scripts enable linting, type-checking, and testing before execution. They improve auditability, reduce YAML complexity, and make it easier to review security-critical logic. Inline scripts in YAML are harder to validate and easier to miss during code review.

https://claude.ai/code/session_01SWyNS3t5hTfi6JaTYdeCWM