### PR TITLE
Add peer-review skill, code-reviewer agent, explore-plan skill, and MCP config

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,73 @@
+---
+name: code-reviewer
+description: >
+  Read-only reviewer that inspects the current diff or branch for correctness bugs and
+  reuse/simplification opportunities, with no power to edit. Invoke it for an unbiased second
+  opinion before shipping: after finishing a feature/fix, before opening a PR, or whenever the
+  user asks for a code review of pending changes. Reviews only — it never modifies files.
+tools: Read, Grep, Glob
+model: opus
+---
+
+# Code Reviewer
+
+You are a skeptical reviewer reading a diff from a developer you do not trust. Assume the code is
+wrong until proven otherwise. You have **read-only** tools (Read, Grep, Glob) and no shell, so you
+report findings—you do not fix them, and you cannot run git yourself.
+
+## What to review
+
+Scope your review to the pending changes, not the whole codebase. The diff is handed to you in the
+prompt—review what you are given. Then use Read/Grep/Glob to open the full files around each hunk
+for context, since a hunk in isolation hides broken invariants. If no diff was provided, say so and
+ask for it rather than guessing.
+
+## What to flag
+
+Apply the same lens as `CLAUDE.md`’s Self-Critique Loop and the `pr-creation` critique checklist
+(`.claude/skills/pr-creation/critique-prompt.md`)—read those rather than restating them. In
+priority order:
+
+1. **Correctness**—bugs, broken/missed edge cases, swallowed errors, broken invariants, race
+   conditions, security holes (injection, secrets, unsafe input at boundaries).
+2. **Weakened tests**—skipped/deleted/loosened assertions, tests that no longer test the behavior.
+3. **Reuse & simplification**—duplicated logic that should reuse an existing helper, premature
+   abstractions, dead code, single-caller wrappers, over-nested conditionals.
+4. **Scope creep**—changes beyond what the task requires.
+
+## Do NOT flag
+
+Keep signal high. Stay silent on:
+
+- Style/formatting that Prettier, shfmt, ruff, or the linters already own (quote style, spacing,
+  import order, line length).
+- Subjective preferences with no correctness or clarity payoff (“I’d name this differently”).
+- Pre-existing issues in code **outside** the diff, unless the change directly worsens them.
+- Hypothetical future requirements the task did not ask for.
+- Speculative “you could also” suggestions that add code rather than remove risk.
+
+## Output
+
+For each finding: `file:line`—one-line statement of the problem—why it is wrong. Group by
+severity (Blocker / Should-fix / Nit). If a full pass turns up nothing actionable, say so plainly
+and stop—do not invent issues to look thorough.
+
+## Examples
+
+### Example 1: Real bug
+
+> **Blocker** — `src/auth/session.ts:42` — `expiresAt` compared with `<` instead of `<=`, so a
+> token is treated as valid for one extra second at the exact expiry boundary. The added test on
+> line 88 only checks the far-future case, so it never catches this.
+
+### Example 2: Reuse opportunity
+
+> **Should-fix** — `src/api/users.ts:30-48`—this re-implements the email validation already in
+> `src/lib/validate.ts:validateEmail`. Reuse it instead of duplicating the regex, which has already
+> drifted (missing the `+` subaddress case the shared helper handles).
+
+### Example 3: Clean diff
+
+> No actionable issues. Reviewed the 3-file diff against `main`; correctness, tests, and reuse all
+> check out. One observation (not a blocker): the new `retry` helper has a single caller—fine to
+> keep for readability.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,4 +1,5 @@
 ---
+# prettier-ignore
 name: code-reviewer
 description: >
   Read-only reviewer that inspects the current diff or branch for correctness bugs and

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000",
+    "CLAUDE_CODE_AUTO_BACKGROUND_TASKS": "1",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/skills/explore-plan/SKILL.md
+++ b/.claude/skills/explore-plan/SKILL.md
@@ -1,0 +1,62 @@
+---
+# prettier-ignore
+name: explore-plan
+description: >
+  Drives the Explore -> Plan -> Review -> Verify discipline for non-trivial, multi-file work before
+  any code is written. Activate when the user asks to "plan this", "scope this out", "figure out how
+  to do X", "explore the codebase first", or is starting a change that touches several files or an
+  unfamiliar area. Enforces a written plan and real verification instead of trusting a success claim.
+---
+
+# Explore / Plan Skill
+
+For non-trivial work, exact context beats approximation and a written plan beats diving in. This
+skill codifies the four-phase loop. Skip it for trivial edits (typos, single-line tweaks)—say so.
+
+## 1. Explore (read-only)
+
+Understand before changing. Use plan mode for read-only tracing of the relevant files and data
+models. Prefer **references over descriptions**: cite `path/to/file.py:42` and read the real code
+rather than guessing. Pipe real errors in (`cat error.log | claude`) instead of paraphrasing them.
+Launch parallel `Explore` agents when scope is uncertain or spans multiple areas.
+
+## 2. Plan (written, explicit)
+
+Before multi-file changes, write an explicit plan: the problem, the approach, the specific files to
+touch, and the existing helpers/patterns to reuse (search for them—do not invent new code when a
+utility already exists). A written plan is reviewable and catches wrong premises before they cost edits.
+
+## 3. Review (fresh, unbiased)
+
+Have the plan—and later the diff—reviewed with no implementation bias. Use the `peer-review`
+skill, which drives the read-only `code-reviewer` subagent. A reviewer that did not write the plan
+catches assumptions the author cannot see.
+
+## 4. Verify (never trust a success claim)
+
+**Never accept “it works” without evidence.** Before declaring done, produce real output: run the
+tests, run the app and observe behavior, capture a screenshot for UI changes, or paste the real
+command output. Type-checks and a green suite prove code correctness, not feature correctness—if
+you cannot exercise the feature, say so explicitly rather than claiming success.
+
+## Examples
+
+### Example 1: Multi-file feature
+
+**User says:** “Plan how we’d add rate limiting to the API.”
+
+1. Launches `Explore` agents to map the request middleware and existing config patterns; reads the
+   real middleware files and cites them.
+2. Writes a plan: which middleware to add, where config lives, which existing `RedisClient` helper to
+   reuse, which tests to add.
+3. Runs `peer-review` on the plan—reviewer notes the plan misses the health-check path; fixes it.
+4. After implementing, verifies by hitting the endpoint until throttled and pasting the 429 response.
+
+### Example 2: Unfamiliar bug
+
+**User says:** “Figure out why login intermittently 500s, then fix it.”
+
+1. Explores: greps the auth path, reads the session store code, pipes in the real stack trace.
+2. Writes a short plan pinpointing the suspected race in token refresh.
+3. Implements the fix, then verifies by reproducing the original failure and showing it now passes —
+   not by asserting the change “should” fix it.

--- a/.claude/skills/peer-review/SKILL.md
+++ b/.claude/skills/peer-review/SKILL.md
@@ -1,0 +1,76 @@
+---
+# prettier-ignore
+name: peer-review
+description: >
+  Runs a fresh, unbiased review of pending changes by delegating to the read-only code-reviewer
+  subagent, then triages and fixes the findings. Activate when the user asks to "review this",
+  "peer review", "get a second opinion", "review my changes/diff/branch", or wants a review pass
+  before opening a PR. Distinct from the built-in /code-review and /review skills: this one drives
+  the project's code-reviewer agent to a fixed point.
+---
+
+# Peer Review Skill
+
+Codifies the “fresh second-Claude reviewer, no implementation bias” pattern: a separate read-only
+agent reviews the diff so the author’s intent does not color the review. Use this before shipping or
+whenever an unbiased look at pending changes is wanted.
+
+## Workflow
+
+### 1. Capture the diff
+
+Compute the review target and keep the text: the diff against the base branch
+(`git diff "$CLAUDE_CODE_BASE_REF"...HEAD`), or uncommitted work (`git diff` / `git diff --cached`).
+
+### 2. Launch the reviewer
+
+Invoke the **`code-reviewer`** subagent (`.claude/agents/code-reviewer.md`) via the Agent tool,
+passing the diff text from step 1 **in the prompt**—the agent is read-only (Read/Grep/Glob,
+`model: opus`) with no shell, so it cannot fetch the diff itself. It reads the surrounding files for
+context on its own.
+
+### 3. Triage and fix
+
+For each finding, assess validity first—the reviewer can be wrong. Then:
+
+- **Blocker / Should-fix**: fix it, re-running the project’s tests/lint as needed.
+- **Nit**: apply if cheap; otherwise note and move on.
+- **Invalid**: state why in one line and skip.
+
+Do not weaken or delete tests to make a finding “go away” (see `CLAUDE.md`).
+
+### 4. Re-review to a fixed point
+
+After fixing, launch a fresh `code-reviewer` pass (with the updated diff)—fixes introduce their
+own bugs and the prior review is now stale. Stop when a full pass returns nothing actionable. Cap at
+~5 passes; if findings persist at pass 5, summarize what is left and ask the user rather than looping
+silently.
+
+### 5. Report
+
+Summarize what the reviewer flagged, what you fixed, and anything deliberately deferred.
+
+## When NOT to use
+
+- Creating a PR end-to-end—use `pr-creation` (it already runs its own critique loop).
+- Trivial edits (typo fixes, single-line config tweaks)—say so and skip.
+
+## Examples
+
+### Example 1: Pre-PR review
+
+**User says:** “Review my changes before I open the PR.”
+
+1. Runs `git diff "$CLAUDE_CODE_BASE_REF"...HEAD`—4 files changed.
+2. Launches `code-reviewer`, passing that diff in the prompt.
+3. Reviewer returns one Blocker (off-by-one in pagination) and one Should-fix (duplicated parser).
+4. Fixes both, reruns `pnpm test`—green. Commits.
+5. Re-reviews with the new diff—clean. Reports the two fixes and that the second pass found nothing.
+
+### Example 2: Reviewer disagreement
+
+**User says:** “Peer review this branch.”
+
+1. Launches `code-reviewer` with the branch diff; it flags a `try/catch` as a “swallowed error.”
+2. Author checks: the catch rethrows after cleanup—the finding is invalid. States why, skips it.
+3. Applies the reviewer’s other (valid) Nit, re-reviews to a clean pass, reports.

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ out/
 # Claude Code local settings (written by SessionStart hook in web sessions)
 .claude/settings.local.json
 
+# Claude Code personal notes (recurring nitpicks / review feedback, never committed)
+CLAUDE.local.md
+.claude/CLAUDE.local.md
+
 # OS
 .DS_Store
 Thumbs.db

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,20 @@
+{
+  "_comment": "Copy this file to .mcp.json to enable team-shared MCP servers, then run /mcp to verify connections. RESIST TOOL BLOAT: each server expands Claude's reasoning overhead, so start with one or two you actually use and add more only when needed. Personal (non-shared) servers belong in ~/.claude.json, not here. Set the referenced env vars (e.g. GITHUB_PAT) before launching.",
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PAT}"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ pnpm dev / pnpm build / pnpm test / pnpm lint  # If configured in package.json
 
 Use pnpm (not npm) for all package operations.
 
+## Personal Notes
+
+Keep recurring personal nitpicks and review-feedback patterns in `CLAUDE.local.md` (gitignored), separate from the committed project rules here. Prune entries as the habits become automatic, and promote anything that should apply team-wide into this file.
+
 ## Git Workflow
 
 Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <desc>`). The `commit-msg` hook enforces this. Types: feat, fix, refactor, docs, test, chore, ci, style, perf, build. Use `!` for breaking changes.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ These run inside Claude Code sessions (local CLI or cloud), not in CI.
 | `update-pr`            | Updates an existing PR with new changes and optionally revises the description  |
 | `conventional-commits` | Guides Claude through properly formatted commits with secret detection          |
 | `markdown-block`       | Outputs content in a fenced code block so users can copy raw markdown           |
+| `peer-review`          | Runs the read-only `code-reviewer` agent on the diff, then triages and fixes    |
+| `explore-plan`         | Enforces the Explore → Plan → Review → Verify discipline for non-trivial work   |
+
+### Claude Subagents (`.claude/agents/`)
+
+| Agent           | What it does                                                                         |
+| --------------- | ------------------------------------------------------------------------------------ |
+| `code-reviewer` | Read-only reviewer (Read/Grep/Glob, `model: opus`)—unbiased second opinion on a diff |
 
 ### GitHub Actions (`.github/workflows/`)
 
@@ -85,6 +93,28 @@ These run inside Claude Code sessions (local CLI or cloud), not in CI.
 | `pre-commit.yaml`                  | Runs pre-commit hooks in CI                                           |
 | `validate-config.yaml`             | Validates `.claude/` and `.hooks/` config on every push               |
 | `dependabot-auto-merge.yaml`       | Auto-merges minor/patch Dependabot PRs after CI passes                |
+
+### MCP Servers (`.mcp.json`)
+
+Team-shared [MCP servers](https://modelcontextprotocol.io/) live in `.mcp.json` at the repo root. A starter `.mcp.json.example` is included with GitHub, Context7, and Playwright entries:
+
+```bash
+cp .mcp.json.example .mcp.json   # then edit, set any referenced env vars, and run /mcp to verify
+```
+
+**Resist tool bloat**—each server expands Claude’s reasoning overhead, so enable only the ones you actually use and add more on demand. Personal (non-shared) servers belong in `~/.claude.json`, not the committed `.mcp.json`.
+
+### Session Tuning (`.claude/settings.json` env)
+
+The `env` block in `.claude/settings.json` sets defaults tuned for long-running web/automation sessions:
+
+| Variable                                     | Why                                                                    |
+| -------------------------------------------- | ---------------------------------------------------------------------- |
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`     | Compacts earlier to curb context rot on long sessions (tune to taste)  |
+| `CLAUDE_CODE_AUTO_BACKGROUND_TASKS=1`        | Auto-backgrounds long-running commands instead of blocking the session |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` | Disables autoupdater/telemetry/error reporting (CI- and web-safe)      |
+
+See the [Claude Code environment variables reference](https://code.claude.com/docs/en/env-vars) for the full list.
 
 ## How the Pieces Fit Together
 
@@ -138,8 +168,10 @@ Add it as a repository secret named **`TEMPLATE_SYNC_TOKEN`**.
 .
 ├── .claude/
 │   ├── hooks/              # Claude session hooks (SessionStart, PreToolUse)
-│   ├── skills/             # Claude skills (pr-creation, conventional-commits, ...)
-│   └── settings.json       # Claude Code hook configuration
+│   ├── skills/             # Claude skills (pr-creation, peer-review, explore-plan, ...)
+│   ├── agents/             # Claude subagents (code-reviewer)
+│   └── settings.json       # Claude Code hooks + session env tuning
+├── .mcp.json.example       # Starter team-shared MCP servers (copy to .mcp.json)
 ├── .hooks/                 # Git hooks (pre-commit, commit-msg, lint-skills)
 ├── .github/
 │   ├── workflows/          # CI workflows

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "*.json": [
       "prettier --write"
     ],
+    "*.json.example": [
+      "prettier --write --parser json"
+    ],
     "*.{js,jsx,ts,tsx}": [
       "prettier --write"
     ],


### PR DESCRIPTION
## Summary

Adds three new Claude automation tools and supporting infrastructure to enforce code quality and planning discipline:

1. **`peer-review` skill** — Delegates to a read-only `code-reviewer` subagent for unbiased diff review, then triages and fixes findings in a loop until clean.
2. **`code-reviewer` subagent** — Read-only agent (Read/Grep/Glob, Opus model) that reviews diffs for correctness bugs, weakened tests, and reuse opportunities without implementation bias.
3. **`explore-plan` skill** — Enforces the Explore → Plan → Review → Verify discipline for non-trivial multi-file work before any code is written.
4. **`.mcp.json.example`** — Starter team-shared MCP servers (GitHub, Context7, Playwright) with guidance on resisting tool bloat.

## Key Changes

- **`.claude/skills/peer-review/SKILL.md`** — New skill that captures the diff, launches the code-reviewer agent, triages findings (Blocker/Should-fix/Nit), fixes them, and re-reviews to a fixed point (capped at ~5 passes). Includes workflow, examples, and when-not-to-use guidance.
- **`.claude/agents/code-reviewer.md`** — New read-only subagent that reviews diffs for correctness, weakened tests, and reuse opportunities. Flags findings by severity with file:line citations and one-line explanations. Stays silent on style, subjective preferences, and pre-existing issues outside the diff.
- **`.claude/skills/explore-plan/SKILL.md`** — New skill that codifies the four-phase loop: Explore (read-only tracing), Plan (written, explicit), Review (peer-review skill), Verify (real output, never trust success claims). Includes examples for multi-file features and unfamiliar bugs.
- **`.mcp.json.example`** — Starter MCP servers config with GitHub, Context7, and Playwright entries. Includes guidance to resist tool bloat and keep personal servers in `~/.claude.json`.
- **`.claude/settings.json`** — Added `env` block with tuned defaults for long-running sessions: `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`, `CLAUDE_CODE_AUTO_BACKGROUND_TASKS=1`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`.
- **`README.md`** — Updated skills table to include `peer-review` and `explore-plan`; added new "Claude Subagents" and "MCP Servers" sections; documented session tuning env vars.
- **`CLAUDE.md`** — Added "Personal Notes" section encouraging use of `CLAUDE.local.md` (gitignored) for recurring nitpicks, separate from committed project rules.
- **`.gitignore`** — Added entries for `.claude/settings.local.json`, `CLAUDE.local.md`, and `.claude/CLAUDE.local.md`.

## Notable Implementation Details

- The `code-reviewer` agent is intentionally read-only (no shell, no edit tools) to avoid implementation bias—it reviews what the author wrote, not what the author intended.
- The `peer-review` skill drives the reviewer to a fixed point: after each fix, a fresh review pass is run with the updated diff. This catches bugs introduced by fixes and prevents stale review feedback.
- The `explore-plan` skill enforces a written plan before multi-file changes and real verification (test runs, screenshots, command output) before declaring done—never accepting "it works" without evidence.
- MCP servers guidance emphasizes resisting tool bloat: each server expands reasoning overhead, so only enable ones actually used.
- Session tuning env vars in `.claude/settings.json` are tuned for long-running web/automation sessions and can be adjusted per taste.

https://claude.ai/code/session_01C997eHMkX9pGeosW6heo1g