### PR TITLE
Add safe-launch.sh to prevent hook parse errors from blocking sessions

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -75,3 +75,14 @@ Create new skill directories in `skills/` following the pattern in `pr-creatio
 ### Customizing Hooks
 
 Modify `settings.json` to add more hooks. See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) for available hook types.
+
+**Always wrap PreToolUse hooks with `safe-launch.sh`.** A PreToolUse hook that fails to parse (e.g. unresolved merge conflict markers) exits non-zero, which Claude Code treats as a block—locking the session out of repairing the very file that’s broken. `safe-launch.sh` detects the parse failure and degrades open: edits under `.claude/hooks/` and `.hooks/` are allowed for self-repair; all other tools get `permissionDecision: "ask"`.
+
+```json
+{
+  "type": "command",
+  "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/safe-launch.sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/your-new-hook.sh"
+}
+```
+
+Any script under `.claude/hooks/` or `.hooks/` is also syntax-checked at session start by `session-setup.sh`—broken hooks surface as loud warnings before they can block the first tool call.

--- a/.claude/hooks/safe-launch-parse.py
+++ b/.claude/hooks/safe-launch-parse.py
@@ -1,0 +1,36 @@
+"""Extract tool_name and absolute target path from a PreToolUse payload.
+
+Used by safe-launch.sh when the wrapped hook fails to parse, to decide
+whether the in-flight tool call is a self-repair edit on a hook file.
+
+Reads the PreToolUse JSON from stdin and prints two lines: tool_name,
+then the absolute file path (or an empty line if none). On any parse
+failure, exits 0 with empty output so safe-launch falls through to the
+fail-safe "ask" default.
+"""
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return 0
+    project_dir = sys.argv[1]
+    try:
+        data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    name = data.get("tool_name", "") or ""
+    tool_input = data.get("tool_input", {}) or {}
+    path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+    if path and not os.path.isabs(path):
+        path = os.path.join(project_dir, path)
+    print(name)
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -47,24 +47,9 @@ project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
 tool_name=""
 tool_path=""
-if command -v python3 &>/dev/null; then
-  parsed=$(
-    printf '%s' "$payload" | python3 -c '
-import json, os, sys
-project_dir = sys.argv[1]
-try:
-    data = json.loads(sys.stdin.read())
-except Exception:
-    sys.exit(0)
-name = data.get("tool_name", "") or ""
-ti = data.get("tool_input", {}) or {}
-path = ti.get("file_path") or ti.get("notebook_path") or ""
-if path and not os.path.isabs(path):
-    path = os.path.join(project_dir, path)
-print(name)
-print(path)
-' "$project_dir" 2>/dev/null
-  )
+parser="$(dirname "$0")/safe-launch-parse.py"
+if command -v python3 &>/dev/null && [ -f "$parser" ]; then
+  parsed=$(printf '%s' "$payload" | python3 "$parser" "$project_dir" 2>/dev/null)
   tool_name=$(printf '%s\n' "$parsed" | sed -n '1p')
   tool_path=$(printf '%s\n' "$parsed" | sed -n '2p')
 fi
@@ -80,22 +65,22 @@ is_under() {
   [ -n "$parent_dir" ] || return 1
   resolved="$parent_dir/$(basename "$candidate")"
   case "$resolved" in
-    "$parent"/*) return 0 ;;
-    *) return 1 ;;
+  "$parent"/*) return 0 ;;
+  *) return 1 ;;
   esac
 }
 
 case "$tool_name" in
-  Edit | Write | MultiEdit | NotebookEdit)
-    for safe in "$project_dir/.claude/hooks" "$project_dir/.hooks"; do
-      [ -d "$safe" ] || continue
-      safe_resolved=$(cd "$safe" && pwd -P)
-      if is_under "$tool_path" "$safe_resolved"; then
-        echo "safe-launch: allowing self-repair edit under ${safe#"$project_dir/"}" >&2
-        exit 0
-      fi
-    done
-    ;;
+Edit | Write | MultiEdit | NotebookEdit)
+  for safe in "$project_dir/.claude/hooks" "$project_dir/.hooks"; do
+    [ -d "$safe" ] || continue
+    safe_resolved=$(cd "$safe" && pwd -P)
+    if is_under "$tool_path" "$safe_resolved"; then
+      echo "safe-launch: allowing self-repair edit under ${safe#"$project_dir/"}" >&2
+      exit 0
+    fi
+  done
+  ;;
 esac
 
 # Default: surface the failure as an "ask" decision so the user can choose.

--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -69,12 +69,16 @@ print(path)
   tool_path=$(printf '%s\n' "$parsed" | sed -n '2p')
 fi
 
-# Lexical + symlink-resolving containment check.
+# Lexical + symlink-resolving containment check. Fails closed: any error
+# (missing parent dir, cd failure, unset args) returns non-zero so the
+# caller falls through to the "ask" default.
 is_under() {
-  local candidate="$1" parent="$2" resolved
+  local candidate="$1" parent="$2" parent_dir resolved
   [ -n "$candidate" ] && [ -n "$parent" ] || return 1
   case "$candidate" in *..*) return 1 ;; esac
-  resolved=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P)/$(basename "$candidate")
+  parent_dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
+  [ -n "$parent_dir" ] || return 1
+  resolved="$parent_dir/$(basename "$candidate")"
   case "$resolved" in
     "$parent"/*) return 0 ;;
     *) return 1 ;;

--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Resilient launcher for PreToolUse hooks.
+#
+# Usage:  safe-launch.sh <hook-script> [args...]
+#
+# Wrap any PreToolUse hook with this script in settings.json so that a syntax
+# error in the underlying hook (e.g. an unresolved merge conflict marker)
+# can never lock the session.
+#
+# Behavior:
+#   * Fast path — if <hook-script> parses cleanly, exec it. The PreToolUse
+#     stdin payload is forwarded transparently.
+#   * Degraded path — if <hook-script> fails `bash -n`, fall back to a
+#     fail-safe policy instead of exiting non-zero (which Claude Code would
+#     treat as a tool block):
+#       - Edit/Write/MultiEdit/NotebookEdit targeting .claude/hooks/ or
+#         .hooks/ are allowed so the broken hook can be repaired in-session.
+#       - Everything else returns permissionDecision="ask", forcing a
+#         conscious user override on a tool-by-tool basis.
+#
+# This mirrors the launcher shim from
+# alexander-turner/secure-claude-code-defaults#109.
+
+set -uo pipefail
+
+target="${1:-}"
+shift || true
+
+if [ -z "$target" ] || [ ! -f "$target" ]; then
+  echo "safe-launch: missing target hook: $target" >&2
+  exit 1
+fi
+
+# Fast path: target parses — run it as-is. The PreToolUse stdin payload is
+# inherited automatically because we exec into the target.
+if bash -n "$target" 2>/dev/null; then
+  exec "$target" "$@"
+fi
+
+# Degraded path. Read the PreToolUse payload before we touch stdin again.
+parse_error=$(bash -n "$target" 2>&1)
+echo "safe-launch: target hook failed to parse — degrading open: $target" >&2
+[ -n "$parse_error" ] && echo "$parse_error" >&2
+
+payload=$(cat)
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+tool_name=""
+tool_path=""
+if command -v python3 &>/dev/null; then
+  parsed=$(
+    printf '%s' "$payload" | python3 -c '
+import json, os, sys
+project_dir = sys.argv[1]
+try:
+    data = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(0)
+name = data.get("tool_name", "") or ""
+ti = data.get("tool_input", {}) or {}
+path = ti.get("file_path") or ti.get("notebook_path") or ""
+if path and not os.path.isabs(path):
+    path = os.path.join(project_dir, path)
+print(name)
+print(path)
+' "$project_dir" 2>/dev/null
+  )
+  tool_name=$(printf '%s\n' "$parsed" | sed -n '1p')
+  tool_path=$(printf '%s\n' "$parsed" | sed -n '2p')
+fi
+
+# Lexical + symlink-resolving containment check.
+is_under() {
+  local candidate="$1" parent="$2" resolved
+  [ -n "$candidate" ] && [ -n "$parent" ] || return 1
+  case "$candidate" in *..*) return 1 ;; esac
+  resolved=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P)/$(basename "$candidate")
+  case "$resolved" in
+    "$parent"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+case "$tool_name" in
+  Edit | Write | MultiEdit | NotebookEdit)
+    for safe in "$project_dir/.claude/hooks" "$project_dir/.hooks"; do
+      [ -d "$safe" ] || continue
+      safe_resolved=$(cd "$safe" && pwd -P)
+      if is_under "$tool_path" "$safe_resolved"; then
+        echo "safe-launch: allowing self-repair edit under ${safe#"$project_dir/"}" >&2
+        exit 0
+      fi
+    done
+    ;;
+esac
+
+# Default: surface the failure as an "ask" decision so the user can choose.
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"safe-launch: PreToolUse hook failed to parse; manual override required."}}
+JSON
+exit 0

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -47,6 +47,39 @@ webi_install_if_missing() {
 }
 
 #######################################
+# Hook syntax validation
+#######################################
+
+# A hook script with a syntax error (e.g. unresolved merge conflict markers)
+# exits non-zero before any logic runs, which Claude Code treats as a block.
+# Surface broken hooks at session start so they can be fixed before the first
+# tool call dies with no explanation.
+_check_hook_syntax() {
+  local dir file out
+  for dir in "$PROJECT_DIR/.claude/hooks" "$PROJECT_DIR/.hooks"; do
+    [ -d "$dir" ] || continue
+    while IFS= read -r -d '' file; do
+      case "$file" in
+        *.sh | *.bash)
+          if ! out=$(bash -n "$file" 2>&1); then
+            warn "hook has bash syntax error: ${file#"$PROJECT_DIR/"}"
+            [ -n "$out" ] && echo "$out" >&2
+          fi
+          ;;
+        *.py)
+          if command -v python3 &>/dev/null && ! out=$(python3 -m py_compile "$file" 2>&1); then
+            warn "hook has python syntax error: ${file#"$PROJECT_DIR/"}"
+            [ -n "$out" ] && echo "$out" >&2
+          fi
+          ;;
+      esac
+    done < <(find "$dir" -maxdepth 1 -type f -print0)
+  done
+}
+
+_check_hook_syntax
+
+#######################################
 # PATH setup
 #######################################
 

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -60,18 +60,18 @@ _check_hook_syntax() {
     [ -d "$dir" ] || continue
     while IFS= read -r -d '' file; do
       case "$file" in
-        *.sh | *.bash)
-          if ! out=$(bash -n "$file" 2>&1); then
-            warn "hook has bash syntax error: ${file#"$PROJECT_DIR/"}"
-            [ -n "$out" ] && echo "$out" >&2
-          fi
-          ;;
-        *.py)
-          if command -v python3 &>/dev/null && ! out=$(python3 -m py_compile "$file" 2>&1); then
-            warn "hook has python syntax error: ${file#"$PROJECT_DIR/"}"
-            [ -n "$out" ] && echo "$out" >&2
-          fi
-          ;;
+      *.sh | *.bash)
+        if ! out=$(bash -n "$file" 2>&1); then
+          warn "hook has bash syntax error: ${file#"$PROJECT_DIR/"}"
+          [ -n "$out" ] && echo "$out" >&2
+        fi
+        ;;
+      *.py)
+        if command -v python3 &>/dev/null && ! out=$(python3 -m py_compile "$file" 2>&1); then
+          warn "hook has python syntax error: ${file#"$PROJECT_DIR/"}"
+          [ -n "$out" ] && echo "$out" >&2
+        fi
+        ;;
       esac
     done < <(find "$dir" -maxdepth 1 -type f -print0)
   done

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-check.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/safe-launch.sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-check.sh"
           }
         ]
       }

--- a/.github/scripts/validate-config.sh
+++ b/.github/scripts/validate-config.sh
@@ -34,16 +34,30 @@ else
   error ".claude/settings.json not found"
 fi
 
-# 2. All hook scripts are executable and syntactically valid bash
+# 2. Hook scripts are syntactically valid. Files with a shebang must be
+# executable (they're invoked directly); language-helper files without a
+# shebang are loaded by another hook and don't need +x.
 echo "Checking hook script permissions and syntax..."
 for f in .hooks/* .claude/hooks/*; do
   [ -f "$f" ] || continue
-  if [ ! -x "$f" ]; then
-    error "$f is not executable"
+  has_shebang=0
+  IFS= read -r first_line <"$f" || true
+  case "$first_line" in '#!'*) has_shebang=1 ;; esac
+  if [ "$has_shebang" = "1" ] && [ ! -x "$f" ]; then
+    error "$f has a shebang but is not executable"
   fi
-  if ! bash_err=$(bash -n "$f" 2>&1); then
-    error "$f has a bash syntax error: $bash_err"
-  fi
+  case "$f" in
+  *.py)
+    if ! py_err=$(python3 -m py_compile "$f" 2>&1); then
+      error "$f has a python syntax error: $py_err"
+    fi
+    ;;
+  *)
+    if ! bash_err=$(bash -n "$f" 2>&1); then
+      error "$f has a bash syntax error: $bash_err"
+    fi
+    ;;
+  esac
 done
 
 # Summary

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -6,6 +6,14 @@ set -euo pipefail
 
 git_root=$(git rev-parse --show-toplevel)
 
+# Reject unresolved merge conflict markers (and whitespace errors) in staged
+# content. A hook file left with <<<<<<< markers is a bash syntax error that
+# can block every Claude tool call until it's manually repaired.
+if ! git diff --cached --check; then
+  echo "pre-commit: refusing commit — fix the issues above" >&2
+  exit 1
+fi
+
 if [ -d "$git_root/.venv/bin" ]; then
   export PATH="$git_root/.venv/bin:$PATH"
 fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A GitHub template that makes [Claude Code](https://docs.anthropic.com/en/docs/cl
 
 - **A solid starting CLAUDE.md**—upholds high code quality standards, including a self-critique loop that catches bugs before they leave the editor
 - **Pre-push verification**—build, lint, type checks, and tests run automatically before every `git push` or `gh pr create`
+- **Deadlock-proof session hooks**—every hook is syntax-checked at session start, wrapped in a launcher that degrades to “ask” on parse failure, and commits with conflict markers are rejected up front
 - **Skill-driven PR flow**—the `pr-creation` skill runs an iterative compress-critique-fix loop on the diff, then watches CI and fixes failures before reporting back
 - **Enforced code quality**—Conventional Commits (via commitlint), Prettier formatting, and lint-staged run on every commit
 - **`@claude` GitHub integration**—mention Claude in issues or PR comments and it responds with full repo context


### PR DESCRIPTION
## Summary

Introduces `safe-launch.sh`, a resilient launcher wrapper for PreToolUse hooks that prevents syntax errors (e.g., unresolved merge conflict markers) from locking the session. When a hook fails to parse, the wrapper degrades gracefully: edits under `.claude/hooks/` and `.hooks/` are allowed for self-repair, while all other tools require explicit user approval.

## Key Changes

- **New `safe-launch.sh` launcher** (`.claude/hooks/safe-launch.sh`):
  - Fast path: if the target hook parses cleanly, exec it transparently
  - Degraded path: on parse failure, allow Edit/Write/MultiEdit/NotebookEdit targeting hook directories for self-repair; all other tools return `permissionDecision: "ask"` instead of blocking
  - Includes lexical + symlink-resolving containment checks to safely identify hook-directory edits

- **Hook syntax validation at session start** (`session-setup.sh`):
  - New `_check_hook_syntax()` function scans `.claude/hooks/` and `.hooks/` for bash and Python syntax errors
  - Surfaces broken hooks as loud warnings before the first tool call, preventing silent failures

- **Updated PreToolUse hook wrapper** (`.claude/settings.json`):
  - Wraps `pre-push-check.sh` with `safe-launch.sh` to apply the degraded-open pattern

- **Pre-commit merge conflict detection** (`.hooks/pre-commit`):
  - Rejects staged content with unresolved merge markers or whitespace errors
  - Prevents broken hook files from being committed in the first place

- **Documentation** (`.claude/README.md`):
  - Explains the safe-launch pattern and why PreToolUse hooks must be wrapped
  - Includes example configuration snippet

## Implementation Details

- `safe-launch.sh` uses `bash -n` for syntax validation (fast, no execution)
- Python hook validation uses `python3 -m py_compile` for consistency
- Containment check (`is_under()`) resolves symlinks and rejects path traversal attempts
- Payload parsing extracts `tool_name` and file paths via Python JSON parsing for robustness
- All error paths fail closed: missing/unset arguments return non-zero, forcing the "ask" default
- Session-start warnings use the existing `warn()` helper for consistency with other setup checks

## Lessons Learned

**Template repos should wrap all PreToolUse hooks with `safe-launch.sh`.** A PreToolUse hook with a syntax error (merge conflict markers, typos, etc.) exits non-zero before any logic runs, which Claude Code treats as a tool block—locking the session out of repairing the very file that's broken. The safe-launch pattern detects parse failures and degrades open, allowing self-repair edits while requiring explicit approval for other tools. This should be:

1. **Added to the template's `.claude/hooks/safe-launch.sh`** as a standard utility
2. **Documented in template `.claude/README.md`** with the wrapping pattern and rationale
3. **Applied to all PreToolUse hooks in the template's `.claude/settings.json`** by default
4. **Complemented by session-start syntax validation** in `session-setup.sh` to surface broken hooks before they block the first tool call

This prevents a common failure mode where a single typo or unresolved merge conflict in a hook file can render the entire Claude Code session unusable.

https://claude.ai/code/session_01PG5ZYcPE7Pk1fstDsz5Yts