### PR TITLE
docs(CLAUDE.md): add two shell-script lessons from closed issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ Use the `/pr-creation` skill. Before writing a PR description, check for `CONT
 - Smart quotes (U+201C/U+201D/U+2018/U+2019): use Unicode escapes in code, centralize constants, ask user to verify output
 - Fail loudly with clear error messages, only remove error reporting if user asks specifically
 - Shell scripts: never use `|| true` to silence an expected non-zero exit—it silently swallows unexpected failures too. Branch on the exit code instead: `cmd; rc=$?; [ "${rc:-0}" -le N ] || exit "$rc"`.
+- Shell scripts: when checking whether a URL belongs to a specific host, use anchored patterns (`*://github.com/*` or `git@github.com:*`), not substring matching (`*github.com*`)—the latter also matches `github.com.attacker.tld`.
+- Shell scripts / shellcheck: avoid non-ASCII characters in strings that appear in shellcheck’s diagnostic output stream (e.g. test-name labels). `→` breaks shellcheck’s output mid-report (`commitBuffer: invalid argument`); use ASCII `->` instead.
 
 ## Self-Critique Loop
 


### PR DESCRIPTION
## Summary

Incorporates two generalizable shell-script guidelines surfaced from closed issues that weren't yet in CLAUDE.md:

- **URL host anchoring** (from #102): `*github.com*` substring matching also matches `github.com.attacker.tld`; use `*://github.com/*` or `git@github.com:*` instead.
- **shellcheck + non-ASCII** (from #103): non-ASCII characters (e.g. `→`) in strings that appear in shellcheck's diagnostic output stream cause `commitBuffer: invalid argument` and break the report mid-run; use ASCII equivalents (`->`).

Both apply to any repo with shell scripts or hook scripts—neither is specific to a single downstream codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBSxXz9W5ERBNDXyntvWNs)_