### PR TITLE
ci: require privileged author_association for @claude mentions

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -17,11 +17,16 @@ concurrency:
 
 jobs:
   claude:
+    # Require BOTH an `@claude` mention AND a privileged author_association
+    # (OWNER / MEMBER / COLLABORATOR). The mention alone is not an access
+    # boundary—anyone who can comment can type it—so without the association
+    # check a drive-by commenter could start a privileged run (write tokens +
+    # ANTHROPIC_API_KEY) and feed untrusted text to a tool with write access.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Restrict the `@claude` workflow trigger to require both an `@claude` mention AND a privileged author association (OWNER, MEMBER, or COLLABORATOR). This prevents drive-by commenters from invoking privileged runs with write tokens and API keys.

## Changes

- Added comprehensive security check to the `claude` job condition that validates `author_association` on all four trigger types:
  - `issue_comment`: checks `github.event.comment.author_association`
  - `pull_request_review_comment`: checks `github.event.comment.author_association`
  - `pull_request_review`: checks `github.event.review.author_association`
  - `issues`: checks `github.event.issue.author_association`
- Each trigger now requires the author to be in the privileged set `["OWNER", "MEMBER", "COLLABORATOR"]`
- Added detailed inline comment explaining the security rationale: the `@claude` mention alone is not an access boundary since anyone who can comment can type it, so the association check is necessary to prevent untrusted text from reaching tools with write access

## Implementation Details

The condition uses `contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.<source>.author_association)` to check membership in the privileged set across all event types. This ensures consistent security enforcement regardless of how the workflow is triggered.

https://claude.ai/code/session_01XP87EwAFSqrgpzifRqceys