### PR TITLE
ci: add hook-lifecycle smoke test (session setup, pre-commit, pre-push)

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -100,6 +100,13 @@ if ! command -v shellcheck &>/dev/null && is_root; then
   { apt-get update -qq && apt-get install -y -qq shellcheck; } || warn "Failed to install shellcheck"
 fi
 
+# Python projects: the pre-commit and pre-push hooks shell out to ruff, which
+# isn't a project dependency. Install it (pinned to match .pre-commit-config.yaml
+# so local hooks format identically to CI). Skip for non-Python repos.
+if { [ -f "$PROJECT_DIR/pyproject.toml" ] || [ -f "$PROJECT_DIR/uv.lock" ]; } && command -v uv &>/dev/null; then
+  uv_install_if_missing ruff "ruff==0.14.5"
+fi
+
 #######################################
 # Git setup
 #######################################

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -59,6 +59,7 @@ Use imperative mood with a Conventional Commits type prefix:
 - List concrete changes
 - Note any breaking changes
 - Include a “Lessons Learned” section if you discovered generalizable insights that could improve the template (this triggers the phone-home workflow). Each lesson must specify **what** to change, **where**, and **why**—vague observations get ignored. Delete the section entirely if there are no lessons.
+- **Skip the Lessons Learned section entirely when the PR targets the `claude-automation-template` repo itself.** Phone-home propagates lessons _from_ downstream repos _into_ the template; a change made directly in the template is already there, so the section propagates nothing and is just noise.
 
 ## Updating PR Description After Additional Commits
 

--- a/.github/scripts/run-hook-lifecycle.sh
+++ b/.github/scripts/run-hook-lifecycle.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Smoke-test the full Claude hook lifecycle on a clean checkout, in the order a
+# real session hits them: session setup -> pre-commit -> pre-push checks.
+#
+# This catches hooks that break end-to-end (a syntax error, a missing tool, a
+# formatter that errors on the repo's own files) before they reach a session
+# and silently block every tool call. Run by `.github/workflows/hook-lifecycle.yaml`.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# lint-staged stashes the working tree, which needs a committer identity that CI
+# runners don't configure by default.
+git config user.email "ci@example.com"
+git config user.name "CI"
+
+# 1. Session setup. Mirror the Claude harness: hand it an env file and source
+#    the PATH/GH_REPO exports it records, so tools it installs (shfmt, ruff via
+#    uv, jq, ...) are on PATH for the hooks that run afterwards.
+export CLAUDE_ENV_FILE="${RUNNER_TEMP:-/tmp}/claude_env_$$"
+setup_log="${RUNNER_TEMP:-/tmp}/session-setup_$$.log"
+: >"$CLAUDE_ENV_FILE"
+trap 'rm -f "$CLAUDE_ENV_FILE" "$setup_log"' EXIT
+
+echo "::group::session-setup.sh"
+.claude/hooks/session-setup.sh 2>&1 | tee "$setup_log"
+echo "::endgroup::"
+# shellcheck disable=SC1090
+source "$CLAUDE_ENV_FILE"
+
+# session-setup warns (exit 0) instead of failing so a real session can still
+# start, but a hook with a syntax error is exactly the regression this job
+# exists to catch — so promote that specific warning to a hard failure.
+if grep -q "syntax error" "$setup_log"; then
+  echo "session-setup reported a hook with a syntax error — see log above" >&2
+  exit 1
+fi
+
+# 2. Pre-commit hook. Stage any pending changes and run it. lint-staged only ever
+#    acts on changed files, so on a clean checkout there's nothing to format
+#    (repo-wide formatting is covered by the pre-commit and format-check
+#    workflows) — this leg verifies the hook script itself runs without error.
+git add -A
+echo "::group::pre-commit"
+.hooks/pre-commit
+echo "::endgroup::"
+
+# 3. Pre-push checks (build/lint/test/ruff — whichever are configured).
+export CLAUDE_PROJECT_DIR="$repo_root"
+echo "::group::pre-push-check.sh"
+.claude/hooks/pre-push-check.sh
+echo "::endgroup::"
+
+echo "Hook lifecycle completed successfully."

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -44,11 +44,5 @@ jobs:
         with:
           setup-python: "true"
 
-      # The hooks shell out to ruff, which real session environments provide on
-      # PATH but bare runners do not (it is not a project dependency). Pin it to
-      # the same version as .pre-commit-config.yaml so the two stay in sync.
-      - name: Provision ruff
-        run: uv tool install "ruff==0.14.5"
-
       - name: Run hook lifecycle
         run: bash .github/scripts/run-hook-lifecycle.sh

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -1,0 +1,54 @@
+name: Hook lifecycle
+
+# Runs the full Claude hook lifecycle (session setup -> pre-commit -> pre-push)
+# on a clean checkout, so a broken hook is caught in CI rather than in a session.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".claude/hooks/**"
+      - ".hooks/**"
+      - "setup.sh"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".pre-commit-config.yaml"
+      - ".github/scripts/run-hook-lifecycle.sh"
+      - ".github/workflows/hook-lifecycle.yaml"
+  pull_request:
+    paths:
+      - ".claude/hooks/**"
+      - ".hooks/**"
+      - "setup.sh"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".pre-commit-config.yaml"
+      - ".github/scripts/run-hook-lifecycle.sh"
+      - ".github/workflows/hook-lifecycle.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  hook-lifecycle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup base environment
+        uses: ./.github/actions/setup-base-env
+        with:
+          setup-python: "true"
+
+      # The hooks shell out to ruff, which real session environments provide on
+      # PATH but bare runners do not (it is not a project dependency). Pin it to
+      # the same version as .pre-commit-config.yaml so the two stay in sync.
+      - name: Provision ruff
+        run: uv tool install "ruff==0.14.5"
+
+      - name: Run hook lifecycle
+        run: bash .github/scripts/run-hook-lifecycle.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 Use the `/pr-creation` skill. Before writing a PR description, check for `CONTRIBUTING.md` or `.github/PULL_REQUEST_TEMPLATE.md` in the target repo and follow its conventions. **Never** include `claude.ai` URLs, session links, or AI-tool attribution links in PRs. Include a `## Lessons Learned` section **only** for generalizable changes to the template files (e.g., `.claude/`, `.hooks/`, `.github/workflows/`, `CLAUDE.md`, `setup.sh`) that would benefit other downstream repos—the `phone-home.yaml` workflow propagates these to the template repo on merge. Repo-specific fixes do not belong here. Each lesson must be actionable: specify **what** to change in the template, **where** (template file/component), and **why**. Delete the section entirely if there are no template-level lessons—empty or vague lessons create noise.
 
+**Skip the `## Lessons Learned` section entirely when the PR targets the `claude-automation-template` repo itself.** `phone-home.yaml` propagates lessons _from_ downstream repos _into_ the template; a change made directly in the template is already there, so a lessons section here propagates nothing and is pure noise.
+
 **Lessons only reach the template repo if they appear in the PR description**—lessons mentioned only in chat are never propagated by `phone-home.yaml` and are permanently lost.
 
 ## Code Style


### PR DESCRIPTION
## Summary

- A broken hook (syntax error, missing tool, a formatter that errors on the repo's own files) currently surfaces only mid-session, where it can silently block every tool call. This adds a CI job that exercises the **full hook lifecycle on a clean checkout**, in the order a real session hits it, so those regressions are caught in CI instead.
- Closes a real gap the new job exposed: the hooks shell out to `ruff`, which was never installed by `session-setup.sh` (it only worked where the environment happened to ship it). `session-setup.sh` now installs `ruff` for Python projects.
- Clarifies the PR guidance: skip the `## Lessons Learned` section when the PR targets `claude-automation-template` itself.

## Changes

- **`.github/scripts/run-hook-lifecycle.sh`** (new) — runs the three hooks in order:
  1. `.claude/hooks/session-setup.sh` — invoked with a `CLAUDE_ENV_FILE` whose `PATH`/`GH_REPO` exports are then sourced (mirroring the Claude harness) so tools it installs are visible to the later hooks. A `syntax error` warning from session-setup's hook-syntax check is promoted to a hard failure, since that is precisely the regression this job exists to catch.
  2. `.hooks/pre-commit` — `git add -A`, then run the hook. lint-staged only acts on changed files, so on a clean checkout this verifies the hook executes without error (repo-wide formatting is covered by the `pre-commit`/`format-check` workflows).
  3. `.claude/hooks/pre-push-check.sh` — runs whichever build/lint/test/ruff checks are configured.
- **`.github/workflows/hook-lifecycle.yaml`** (new) — runs the script on `push`/`pull_request` (identical `paths` filters on both triggers) via the existing `setup-base-env` action with Python enabled. Third-party action pinned to a commit SHA.
- **`.claude/hooks/session-setup.sh`** — install `ruff` for Python projects (repo has `pyproject.toml`/`uv.lock` and `uv` is available), pinned to the same version as `.pre-commit-config.yaml` so local hooks format identically to CI. This is why the workflow no longer needs a separate ruff-provisioning step.
- **`CLAUDE.md`** / **`.claude/skills/pr-creation/pr-templates.md`** — document that the Lessons Learned section should be skipped when the PR targets the template repo itself.

## Testing

- `bash -n`, `shellcheck -x`, `shfmt -i 2 -d` clean on the new script and the edited `session-setup.sh`; `prettier --check` passes on the workflow YAML and edited markdown.
- Ran `run-hook-lifecycle.sh` end-to-end locally — exits 0 through all three legs.
- CI: the `hook-lifecycle` job (and all other checks) pass; the earlier red runs caught the missing executable bit and the missing ruff, both fixed here.
