### PR TITLE
fix: harden shell strictness, temp-file safety, and jq error handling

### DIFF
--- a/.github/scripts/run-hook-lifecycle.sh
+++ b/.github/scripts/run-hook-lifecycle.sh
@@ -19,9 +19,9 @@ git config user.name "CI"
 # 1. Session setup. Mirror the Claude harness: hand it an env file and source
 #    the PATH/GH_REPO exports it records, so tools it installs (shfmt, ruff via
 #    uv, jq, ...) are on PATH for the hooks that run afterwards.
-export CLAUDE_ENV_FILE="${RUNNER_TEMP:-/tmp}/claude_env_$$"
-setup_log="${RUNNER_TEMP:-/tmp}/session-setup_$$.log"
-: >"$CLAUDE_ENV_FILE"
+CLAUDE_ENV_FILE=$(mktemp "${RUNNER_TEMP:-/tmp}/claude_env_XXXXXX")
+export CLAUDE_ENV_FILE
+setup_log=$(mktemp "${RUNNER_TEMP:-/tmp}/session-setup_XXXXXX.log")
 trap 'rm -f "$CLAUDE_ENV_FILE" "$setup_log"' EXIT
 
 echo "::group::session-setup.sh"

--- a/.github/scripts/validate-config.sh
+++ b/.github/scripts/validate-config.sh
@@ -69,7 +69,10 @@ done
 # merely mentions "safe-launch.sh" in an argument can't pass by accident.
 echo "Checking PreToolUse hooks use safe-launch.sh..."
 if [ -f .claude/settings.json ]; then
-  pretooluse_cmds=$(jq -r '.hooks.PreToolUse // [] | .[] | .hooks[] | select(.type == "command") | .command' .claude/settings.json 2>/dev/null) || pretooluse_cmds=""
+  if ! pretooluse_cmds=$(jq -r '.hooks.PreToolUse // [] | .[] | .hooks[] | select(.type == "command") | .command' .claude/settings.json 2>/dev/null); then
+    error ".claude/settings.json could not be parsed (invalid JSON?)"
+    pretooluse_cmds=""
+  fi
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
     read -ra tokens <<<"$cmd"

--- a/.github/scripts/validate-config.sh
+++ b/.github/scripts/validate-config.sh
@@ -14,7 +14,10 @@ echo ""
 # 1. All hook scripts referenced in .claude/settings.json exist on disk
 echo "Checking Claude hook script paths..."
 if [ -f .claude/settings.json ]; then
-  commands=$(jq -r '.. | objects | select(.command?) | .command' .claude/settings.json 2>/dev/null || true)
+  if ! commands=$(jq -r '.. | objects | select(.command?) | .command' .claude/settings.json 2>/dev/null); then
+    error ".claude/settings.json could not be parsed (invalid JSON?)"
+    commands=""
+  fi
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
     # shellcheck disable=SC2016  # literal $CLAUDE_PROJECT_DIR matched by sed
@@ -66,7 +69,7 @@ done
 # merely mentions "safe-launch.sh" in an argument can't pass by accident.
 echo "Checking PreToolUse hooks use safe-launch.sh..."
 if [ -f .claude/settings.json ]; then
-  pretooluse_cmds=$(jq -r '.hooks.PreToolUse // [] | .[] | .hooks[] | select(.type == "command") | .command' .claude/settings.json)
+  pretooluse_cmds=$(jq -r '.hooks.PreToolUse // [] | .[] | .hooks[] | select(.type == "command") | .command' .claude/settings.json 2>/dev/null) || pretooluse_cmds=""
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
     read -ra tokens <<<"$cmd"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # One-command setup for the Claude automation template
 
-set -e
+set -euo pipefail
 
 echo "Setting up Claude automation template..."
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -4,8 +4,6 @@ Lives in a regular module (not `conftest.py`) so it can be imported directly
 without manipulating `sys.path` or relying on the conftest plugin loader.
 """
 
-from __future__ import annotations
-
 import os
 import shutil
 import subprocess

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Shared pytest fixtures for shell-script tests."""
 
-from __future__ import annotations
-
 import subprocess
 from pathlib import Path
 from typing import Callable, Iterator

--- a/tests/test_check_symlinks.py
+++ b/tests/test_check_symlinks.py
@@ -1,7 +1,5 @@
 """Tests for .github/scripts/check-symlinks.sh."""
 
-from __future__ import annotations
-
 import subprocess
 from pathlib import Path
 

--- a/tests/test_check_token_scope.py
+++ b/tests/test_check_token_scope.py
@@ -5,8 +5,6 @@ exits non-zero when TOKEN is unset. This module covers the actual scope-check
 behaviour by injecting a fake `curl` that returns controlled header output.
 """
 
-from __future__ import annotations
-
 import os
 import subprocess
 from pathlib import Path

--- a/tests/test_lint_skills.py
+++ b/tests/test_lint_skills.py
@@ -1,7 +1,5 @@
 """Tests for .hooks/lint-skills.sh."""
 
-from __future__ import annotations
-
 import subprocess
 from pathlib import Path
 

--- a/tests/test_required_env.py
+++ b/tests/test_required_env.py
@@ -3,8 +3,6 @@ message) when a required env var is unset. This catches the regression where
 a workflow change silently drops an env var, leaving the script to misbehave
 on an empty value."""
 
-from __future__ import annotations
-
 import subprocess
 from pathlib import Path
 

--- a/tests/test_script_configured.py
+++ b/tests/test_script_configured.py
@@ -1,7 +1,5 @@
 """Tests for .github/scripts/script-configured.sh."""
 
-from __future__ import annotations
-
 import json
 import shutil
 import subprocess

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -5,8 +5,6 @@ repo, runs the sync script with controlled inputs, and asserts on the
 resulting file contents + GITHUB_OUTPUT entries.
 """
 
-from __future__ import annotations
-
 import os
 import subprocess
 from pathlib import Path

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -99,13 +99,14 @@ def test_fails_when_settings_missing(tmp_path: Path, copy_script) -> None:
 
 
 def test_fails_when_settings_json_is_malformed(tmp_path: Path, copy_script) -> None:
-    """Corrupted settings.json must be reported as an error, not silently pass."""
-    (tmp_path / ".claude").mkdir()
+    """Corrupted settings.json must be reported as an error for both jq call sites,
+    not silently swallowed."""
+    (tmp_path / ".claude").mkdir(exist_ok=True)
     (tmp_path / ".claude" / "settings.json").write_text("{not valid json}")
     make_hook(tmp_path, ".hooks/pre-commit", executable=True)
     result = run_validator(tmp_path, copy_script)
     assert result.returncode == 1
-    assert "could not be parsed" in result.stdout + result.stderr
+    assert (result.stdout + result.stderr).count("could not be parsed") == 2
 
 
 def test_rejects_hook_with_syntax_error(tmp_path: Path, copy_script) -> None:

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -1,7 +1,5 @@
 """Tests for .github/scripts/validate-config.sh."""
 
-from __future__ import annotations
-
 import json
 import subprocess
 from pathlib import Path
@@ -98,6 +96,16 @@ def test_fails_when_settings_missing(tmp_path: Path, copy_script) -> None:
     result = run_validator(tmp_path, copy_script)
     assert result.returncode == 1
     assert ".claude/settings.json not found" in result.stdout
+
+
+def test_fails_when_settings_json_is_malformed(tmp_path: Path, copy_script) -> None:
+    """Corrupted settings.json must be reported as an error, not silently pass."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text("{not valid json}")
+    make_hook(tmp_path, ".hooks/pre-commit", executable=True)
+    result = run_validator(tmp_path, copy_script)
+    assert result.returncode == 1
+    assert "could not be parsed" in result.stdout + result.stderr
 
 
 def test_rejects_hook_with_syntax_error(tmp_path: Path, copy_script) -> None:


### PR DESCRIPTION
## Summary

- `validate-config.sh` silently swallowed corrupted `settings.json` (a `|| true` on both jq calls let parse errors disappear, so validation reported "All checks passed" on malformed JSON)
- `run-hook-lifecycle.sh` used `$$`-based temp-file names instead of `mktemp`, leaving a PID-collision/predictable-name race in shared `/tmp`
- `setup.sh` used `set -e` instead of `set -euo pipefail`, unlike every other script in the repo — unset-variable and pipe failures were silently ignored
- Nine test files carried `from __future__ import annotations` without needing it, violating CLAUDE.md policy for Python 3.11

## Changes

- **`setup.sh`**: `set -e` → `set -euo pipefail`
- **`validate-config.sh`** (check-1): replace `|| true` with `if ! jq ...; then error "...could not be parsed..."; fi`
- **`validate-config.sh`** (check-3): same `if !` pattern for the PreToolUse jq call — previously used `|| pretooluse_cmds=""` which swallowed the error without reporting it
- **`run-hook-lifecycle.sh`**: replace `$$`-based temp-file paths + `: >` creation with `mktemp`
- **`tests/*.py`** (9 files): remove `from __future__ import annotations`
- **`tests/test_validate_config.py`**: add `test_fails_when_settings_json_is_malformed` — asserts `count("could not be parsed") == 2` to pin both jq call sites

## Testing

- `uv run --extra dev pytest tests/ -x -q` — 60 passed
- Critique loop run to fixed point (3 passes, 2 with findings, 1 clean)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcvoNqzyfwhNkRx2JNTktH)_