### PR TITLE
ci: add zizmor security audit and fix GitHub Actions security issues

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -105,6 +105,7 @@ fi
 # so local hooks format identically to CI). Skip for non-Python repos.
 if { [ -f "$PROJECT_DIR/pyproject.toml" ] || [ -f "$PROJECT_DIR/uv.lock" ]; } && command -v uv &>/dev/null; then
   uv_install_if_missing ruff "ruff==0.14.5"
+  uv_install_if_missing zizmor "zizmor==1.25.2"
 fi
 
 #######################################

--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -30,7 +30,7 @@ runs:
     - name: Get pnpm store directory
       if: hashFiles('package.json') != ''
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env]
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
     - name: Restore pnpm cache
@@ -56,8 +56,10 @@ runs:
 
     - name: Set up Python
       if: inputs.setup-python == 'true'
-      run: uv python install ${{ inputs.python-version }}
+      run: uv python install "$PYTHON_VERSION"
       shell: bash
+      env:
+        PYTHON_VERSION: ${{ inputs.python-version }}
 
     - name: Install Python Dependencies
       if: inputs.setup-python == 'true'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
       npm-tracked:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -36,11 +36,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -12,7 +12,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -12,9 +12,10 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -37,7 +37,9 @@ jobs:
   hook-lifecycle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,7 +26,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -26,7 +26,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -22,9 +22,10 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'phone-home')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github/scripts
+          persist-credentials: false
 
       - name: Extract lessons from PR body
         id: extract

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,7 +12,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -33,7 +33,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
@@ -64,7 +66,7 @@ jobs:
 
       - name: Triage and fix with Claude
         id: triage
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -64,19 +64,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout child repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           filter: blob:none
+          persist-credentials: false
 
       - name: Checkout template repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ env.TEMPLATE_REPO }}
           path: _template
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           filter: blob:none
+          persist-credentials: false
 
       - name: Check token workflow scope
         env:

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -23,7 +23,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -6,12 +6,10 @@ on:
   push:
     branches: ["main"]
     paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
+      - ".github/**"
   pull_request:
     paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
+      - ".github/**"
 
 permissions:
   contents: read

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,30 @@
+name: zizmor
+
+# Security audit of GitHub Actions workflows and composite actions.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+
+      - name: Run zizmor
+        run: uvx zizmor==1.25.2 .github/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,8 @@ repos:
         language: python
         additional_dependencies: ["zizmor==1.25.2"]
         pass_filenames: false
-        files: ^\.github/(workflows|actions)/
+        args: [".github/"]
+        files: ^\.github/
 
       - id: validate-config
         name: validate Claude hook configuration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: zizmor
+        name: zizmor (GitHub Actions security audit)
+        entry: zizmor
+        language: python
+        additional_dependencies: ["zizmor==1.25.2"]
+        pass_filenames: false
+        files: ^\.github/(workflows|actions)/
+
       - id: validate-config
         name: validate Claude hook configuration
         entry: bash .github/scripts/validate-config.sh


### PR DESCRIPTION
## Summary

Add GitHub Actions security auditing via [zizmor](https://github.com/astral-sh/zizmor) and remediate security findings across all workflows and composite actions.

## Changes

- **New workflow**: `.github/workflows/zizmor.yaml` runs zizmor on push/PR to audit GitHub Actions workflows and composite actions for security issues
- **Pre-commit hook**: Added zizmor to `.pre-commit-config.yaml` to catch security issues locally before commit
- **Session setup**: Added zizmor installation to `.claude/hooks/session-setup.sh` for local development
- **Security fixes across workflows**:
  - Added `persist-credentials: false` to all `actions/checkout` steps (prevents token leakage via git config)
  - Updated `actions/checkout` version comments from `# v6` to `# v6.0.2` for precision
  - Updated `anthropics/claude-code-action` version comments from `# v1` to `# v1.0.133` for precision
  - Fixed `.github/actions/setup-base-env/action.yaml`:
    - Moved `${{ inputs.python-version }}` into environment variable to avoid shell injection risk
    - Added `# zizmor: ignore[github-env]` comment to pnpm store path step (legitimate use of `$GITHUB_ENV`)
- **Fixed dependabot detection**: Changed `github.actor == 'dependabot[bot]'` to `github.event.pull_request.user.login == 'dependabot[bot]'` in `dependabot-auto-merge.yaml` (more reliable actor detection)

## Implementation Details

Zizmor is configured to scan `.github/workflows/` and `.github/actions/` on every push to main and all PRs. The tool identifies common GitHub Actions security anti-patterns (exposed credentials, unsafe shell variable interpolation, missing permission scoping, etc.). All findings have been remediated to pass zizmor validation.

https://claude.ai/code/session_01UZBp7jvAA6Pva2geMAaACu