### PR TITLE
chore: expand session permissions for common dev tasks

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -169,7 +169,15 @@ if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
     "allow": [
       "Edit(.claude/**)",
       "Write(.claude/**)",
-      "Read(.claude/**)"
+      "Read(.claude/**)",
+      "Bash(pnpm build)",
+      "Bash(pnpm check:*)",
+      "Bash(pnpm format)",
+      "Bash(pnpm install)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pre-commit run:*)",
+      "Bash(uv run pytest:*)"
     ]
   }
 }

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -167,9 +167,9 @@ if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
 {
   "permissions": {
     "allow": [
-      "Edit .claude/**",
-      "Write .claude/**",
-      "Read .claude/**"
+      "Edit(.claude/**)",
+      "Write(.claude/**)",
+      "Read(.claude/**)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,16 +11,6 @@
       "Read(**/.env.*)",
       "Read(**/*.pem)",
       "Read(**/*.key)"
-    ],
-    "allow": [
-      "Bash(pnpm build)",
-      "Bash(pnpm check:*)",
-      "Bash(pnpm format)",
-      "Bash(pnpm install)",
-      "Bash(pnpm lint:*)",
-      "Bash(pnpm test:*)",
-      "Bash(pre-commit run:*)",
-      "Bash(uv run pytest:*)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,24 @@
     "CLAUDE_CODE_AUTO_BACKGROUND_TASKS": "1",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
   },
+  "permissions": {
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)"
+    ],
+    "allow": [
+      "Bash(pnpm build)",
+      "Bash(pnpm check:*)",
+      "Bash(pnpm format)",
+      "Bash(pnpm install)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm test:*)",
+      "Bash(pre-commit run:*)",
+      "Bash(uv run pytest:*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Adds a security baseline to the committed Claude Code settings and pre-approves routine dev commands in web sessions, so common workflows run without permission prompts.

## Changes

- **`.claude/settings.json`**: add `deny` rules blocking `Read` of sensitive files (`**/.env`, `**/.env.*`, `**/*.pem`, `**/*.key`). These apply everywhere the repo settings are loaded.
- **`.claude/hooks/session-setup.sh`**: the web-session-only `settings.local.json` it generates now also allows routine Bash commands (`pnpm build/check/format/install/lint/test`, `pre-commit run`, `uv run pytest`). These allow rules are deliberately scoped to web sessions rather than committed in `settings.json`, so they don't apply on contributors' machines.
- Fix the permission rule syntax in the generated file from the invalid space-separated form (`"Edit .claude/**"`) to the valid `Tool(pattern)` form (`"Edit(.claude/**)"`) — the old form was silently ignored, so the self-edit grant never took effect.

## Verification

- `bash -n` passes on `session-setup.sh`
- `settings.json` and the heredoc JSON both parse cleanly