### PR TITLE
fix: improve HTML comment and tag filtering in phone-home script

### DIFF
--- a/.github/scripts/phone-home-extract.js
+++ b/.github/scripts/phone-home-extract.js
@@ -45,10 +45,13 @@ module.exports = async ({ context, core }) => {
     return;
   }
 
+  // Strip HTML comments first with a newline-aware pattern so multi-line
+  // <!-- ... --> placeholders are removed too (a per-line /^<!--.*-->$/ only
+  // catches single-line comments).
   const filtered = lessons
+    .replace(/<!--[\s\S]*?-->/g, "")
     .split("\n")
-    .filter((line) => !line.trim().match(/^<.*>$/))
-    .filter((line) => !line.trim().match(/^<!--.*-->$/))
+    .filter((line) => !line.trim().match(/^<[^>]*>$/))
     .filter(
       (line) => !line.trim().match(/^https:\/\/claude\.ai\/code\/session_/),
     )


### PR DESCRIPTION
## Summary
Fixes the phone-home extraction script to correctly handle multi-line HTML comments and improves tag filtering robustness.

## Changes
- **Multi-line comment handling**: Added a regex pass (`/<!--[\s\S]*?-->/g`) that strips HTML comments before line splitting. This catches multi-line `<!-- ... -->` blocks that the previous per-line filter missed.
- **Removed redundant filter**: Deleted the per-line single-line comment filter (`/^<!--.*-->$/`) since it's now handled by the upfront regex pass.
- **Improved tag filter**: Changed the tag-matching regex from `/^<.*>$/` to `/^<[^>]*>$/` to be more precise—the original pattern could match lines with unbalanced angle brackets (e.g., `<tag attr="value>text"`), while the new pattern only matches well-formed tags.

## Implementation Details
The regex `/<!--[\s\S]*?-->/g` uses `[\s\S]` to match any character including newlines (since `.` does not match newlines by default), and the non-greedy `*?` ensures it stops at the first `-->` rather than consuming to the last one in the file.

The improved tag filter `/^<[^>]*>$/` matches only lines that are entirely composed of a single tag (opening, closing, or self-closing), rejecting lines with mixed content or malformed tags.

https://claude.ai/code/session_013ZnucrJ4y6GYhFZ2KWXKha