### PR TITLE
ci: remove phone-home label requirement from workflow trigger

### DIFF
--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -16,10 +16,7 @@ permissions:
 
 jobs:
   phone-home:
-    # Only run for merged PRs that have the phone-home label
-    if: >
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'phone-home')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Simplifies the `phone-home` workflow trigger condition by removing the label check, allowing the workflow to run on all merged PRs rather than only those explicitly labeled with `phone-home`.

## Changes

- Removed the `contains(github.event.pull_request.labels.*.name, 'phone-home')` condition from the workflow `if` statement
- Kept the `github.event.pull_request.merged == true` check to ensure the workflow only runs on merged PRs

## Rationale

This change streamlines the workflow by eliminating the need to manually label PRs. The workflow will now automatically execute for all merged pull requests, reducing friction in the merge process while maintaining the core requirement that only merged PRs trigger the phone-home action.

https://claude.ai/code/session_01Em14aWid1oQ17hXEXv5zXc