### PR TITLE
docs: add iteration retrospective step to PR creation skill

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -134,6 +134,17 @@ Skip this step if no commits were made after Step 4.
 
 Provide the PR URL and confirm all CI checks have passed.
 
+### Step 8: Iteration Retrospective
+
+After reporting the result, briefly reflect on how you could have iterated faster on this task. Consider:
+
+- **Parallelization**: Which investigations, tool calls, or sub-agent launches could have run in parallel instead of sequentially?
+- **Targeted checks over full sweeps**: Were there broad searches or full test runs you ran locally that CI would have caught anyway? Could a more targeted check (single file, single test, quick lint) have been faster?
+- **Earlier CI delegation**: Could you have pushed earlier and let CI surface issues rather than exhaustively validating locally first?
+- **Critique loop efficiency**: Did any critique passes surface issues that a quick re-read would have caught before launching the sub-agent?
+
+State each insight as one concrete line. Skip this step if the task was trivial (single-file, no iteration needed).
+
 ## Examples
 
 ### Example 1: Simple Bug Fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ Each pass, hunt for: bugs, broken or missed edge cases, weakened/skipped/delete
 
 Stop only when a full pass turns up **nothing** worth changing. Cap at ~5 passes; if you’re still finding real issues at pass 5, say so and ask the user rather than silently giving up. Skip the loop for trivial edits (typo fixes, single-line config tweaks, pure questions)—say so explicitly when you skip.
 
+After completing any non-trivial task, briefly reflect on how you could have iterated faster. Consider: which investigations or tool calls could have run in parallel? Were there full sweeps you ran locally that CI would have caught anyway—could a targeted check (single file, single test, quick lint) have been faster? Could you have pushed earlier and delegated validation to CI? State each insight as one concrete line; skip this for trivial tasks.
+
 ## CI / GitHub Actions
 
 - **Extract significant inline scripts** from workflow YAML into standalone files under `.github/scripts/` so they can be linted, type-checked, and tested independently. Inline scripts in `run:` or `script:` blocks are invisible to linters, shellcheck, `@ts-check`, and test frameworks. Rule of thumb: if the inline block exceeds ~10 lines or contains branching logic, extract it. Shell scripts go in `.github/scripts/*.sh`; JS scripts used by `actions/github-script` go in `.github/scripts/*.js` (with `@ts-check` and JSDoc types) and are loaded via `require('./.github/scripts/foo.js')`. Keep trivial glue (single commands, simple output-setting) inline.


### PR DESCRIPTION
## Summary

Adds a new Step 8 to the PR creation skill that prompts for a brief retrospective on iteration speed after completing a PR. This formalizes the practice of reflecting on parallelization opportunities, targeted checks vs. full sweeps, and earlier CI delegation.

## Changes

- **`.claude/skills/pr-creation/SKILL.md`**: Added Step 8 (Iteration Retrospective) after the CI check confirmation step. Guides reflection on:
  - Parallelization of investigations, tool calls, or sub-agent launches
  - Targeted checks (single file, single test, quick lint) vs. full local sweeps that CI would catch anyway
  - Earlier CI delegation instead of exhaustive local validation
  - Critique loop efficiency before launching sub-agents
  - Explicitly skips trivial tasks (single-file, no iteration needed)

- **`CLAUDE.md`**: Added corresponding guidance in the Self-Critique Loop section to reflect on iteration speed after non-trivial tasks, with the same considerations and skip condition for trivial work.

Both additions use consistent language and criteria to encourage faster iteration cycles by identifying bottlenecks in the development workflow.

https://claude.ai/code/session_01QcrgyTMQ6LkaJTmWfantJA