### PR TITLE
fix(ci): harden workflows and fix error-handling policy violations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,14 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -79,9 +79,14 @@ trap 'rm -f "$socket_tmp"' EXIT
 for pr_num in $(gh api "repos/${REPO}/pulls?state=open&per_page=5" --jq '.[].number' 2>/dev/null); do
   # Fetch once into a temp file; avoids a second API call and command
   # substitution (which strips trailing newlines and merges multi-comment output).
-  gh api "repos/${REPO}/issues/${pr_num}/comments?per_page=30" \
+  if ! gh api "repos/${REPO}/issues/${pr_num}/comments?per_page=30" \
     --jq '.[] | select(.user.login == "socket-security[bot]") | .body' \
-    >"$socket_tmp" 2>/dev/null || true
+    >"$socket_tmp" 2>/dev/null; then
+    # Tolerate a single PR's comment fetch failing (permissions/transient API
+    # error) — it must not abort the whole security report. Reset to empty so a
+    # prior iteration's content can't leak into this PR's section.
+    : >"$socket_tmp"
+  fi
   if [ -s "$socket_tmp" ]; then
     socket_found=true
     {

--- a/.github/scripts/phone-home-extract.js
+++ b/.github/scripts/phone-home-extract.js
@@ -19,8 +19,13 @@ const PHONE_HOME_DIR = "/tmp/phone-home";
 module.exports = async ({ context, core }) => {
   const prBody = context.payload.pull_request.body || "";
   const repo = `${context.repo.owner}/${context.repo.repo}`;
+  const templateRepo = process.env.TEMPLATE_REPO;
 
-  if (repo === process.env.TEMPLATE_REPO) {
+  if (!templateRepo) {
+    throw new Error("TEMPLATE_REPO env var is required");
+  }
+
+  if (repo === templateRepo) {
     console.log("This IS the template repo, skipping phone-home");
     return;
   }

--- a/.github/scripts/phone-home-submit.js
+++ b/.github/scripts/phone-home-submit.js
@@ -16,10 +16,16 @@ const PHONE_HOME_DIR = "/tmp/phone-home";
  */
 module.exports = async ({ github }) => {
   const lessons = fs.readFileSync(`${PHONE_HOME_DIR}/lessons.txt`, "utf8");
-  const prTitle = /** @type {string} */ (process.env.PR_TITLE);
-  const prUrl = /** @type {string} */ (process.env.PR_URL);
-  const repo = /** @type {string} */ (process.env.SOURCE_REPO);
-  const templateRepo = /** @type {string} */ (process.env.TEMPLATE_REPO);
+  const prTitle = process.env.PR_TITLE;
+  const prUrl = process.env.PR_URL;
+  const repo = process.env.SOURCE_REPO;
+  const templateRepo = process.env.TEMPLATE_REPO;
+
+  if (!prTitle || !prUrl || !repo || !templateRepo) {
+    throw new Error(
+      "Missing required env vars: PR_TITLE, PR_URL, SOURCE_REPO, TEMPLATE_REPO must all be set",
+    );
+  }
 
   const issueBody = [
     `## Improvement Suggestion from \`${repo}\``,

--- a/.github/scripts/run-hook-lifecycle.sh
+++ b/.github/scripts/run-hook-lifecycle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Smoke-test the full Claude hook lifecycle on a clean checkout, in the order a
 # real session hits them: session setup -> pre-commit -> pre-push checks.
 #

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -246,7 +246,7 @@ record_no_base_conflict() {
 # project-specific files that were never in the template.
 if [ -n "$PREV_SHA" ]; then
   if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
-    : >"$PREV_TEMPLATE_FILES"  # PREV_SHA not in template history; treat as no prior files
+    : >"$PREV_TEMPLATE_FILES" # PREV_SHA not in template history; treat as no prior files
   fi
 fi
 

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -94,11 +94,11 @@ echo "Current template version: $TEMPLATE_SHA"
 
 if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$TEMPLATE_SHA" ]; then
   if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
-    CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA" || true)
+    CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA")
   else
     echo "::warning::Previous template SHA $PREV_SHA not found in template history (likely rewritten by force-push or rebase)"
     CHANGELOG="Previous SHA \`$PREV_SHA\` no longer exists in template history (force-push/rebase). Showing last 20 commits instead:"$'\n'
-    CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA" || true)
+    CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA")
   fi
   [ -n "$CHANGELOG" ] && emit_multiline_output "changelog" "$CHANGELOG"
 fi
@@ -224,7 +224,12 @@ record_no_base_conflict() {
     echo "<summary>Diff (old local → new template)</summary>"
     echo ""
     echo "\`\`\`diff"
-    diff -u "$rel_path" "$template_file" | head -500 || true
+    # diff exits 0 (identical) or 1 (differs); anything higher is a real error.
+    # Capture into a variable so truncating with `head` can't SIGPIPE the diff.
+    diff_rc=0
+    diff_out=$(diff -u "$rel_path" "$template_file") || diff_rc=$?
+    [ "${diff_rc:-0}" -le 1 ] || exit "${diff_rc}"
+    head -500 <<<"$diff_out"
     echo "\`\`\`"
     echo "</details>"
     echo ""
@@ -240,7 +245,9 @@ record_no_base_conflict() {
 # longer exists at the current template HEAD. This avoids false positives for
 # project-specific files that were never in the template.
 if [ -n "$PREV_SHA" ]; then
-  git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES" || true
+  if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
+    : >"$PREV_TEMPLATE_FILES"  # PREV_SHA not in template history; treat as no prior files
+  fi
 fi
 
 for path in $SYNC_PATHS; do

--- a/.github/scripts/validate-config.sh
+++ b/.github/scripts/validate-config.sh
@@ -44,7 +44,10 @@ echo "Checking hook script permissions and syntax..."
 for f in .hooks/* .claude/hooks/*; do
   [ -f "$f" ] || continue
   has_shebang=0
-  IFS= read -r first_line <"$f" || true
+  # read returns 1 at EOF (empty file = no shebang, fine); >1 is a real error.
+  rc=0
+  IFS= read -r first_line <"$f" || rc=$?
+  [ "${rc:-0}" -le 1 ] || error "Failed to read $f (exit $rc)"
   case "$first_line" in '#!'*) has_shebang=1 ;; esac
   if [ "$has_shebang" = "1" ] && [ ! -x "$f" ]; then
     error "$f has a shebang but is not executable"

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -28,6 +28,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -9,6 +9,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -16,6 +20,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -5,12 +5,17 @@ on:
     branches: ["main"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   format:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -34,6 +39,7 @@ jobs:
     if: always()
     needs: [format]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job did not pass
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -5,12 +5,17 @@ on:
     branches: ["main"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -30,12 +30,17 @@ on:
       - ".github/scripts/run-hook-lifecycle.sh"
       - ".github/workflows/hook-lifecycle.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   hook-lifecycle:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,12 +19,17 @@ on:
       - "package.json"
       - ".github/workflows/lint.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -63,6 +68,7 @@ jobs:
     if: always()
     needs: [lint]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job did not pass
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -19,12 +19,17 @@ on:
       - "package.json"
       - ".github/workflows/node-tests.yaml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -53,6 +58,7 @@ jobs:
     if: always()
     needs: [test]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job did not pass
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -11,6 +11,10 @@ on:
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -21,6 +25,7 @@ jobs:
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'phone-home')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,12 +5,17 @@ on:
     branches: ["main"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -26,6 +31,7 @@ jobs:
     if: always()
     needs: [pre-commit]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job did not pass
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -55,6 +55,10 @@ env:
   # .github/workflows/lint.yaml, .github/workflows/format-check.yaml
   EXCLUDE_PATHS: ""
 
+concurrency:
+  group: template-sync
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -62,6 +66,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout child repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -16,12 +16,18 @@ on:
       - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -44,6 +50,7 @@ jobs:
     if: always()
     needs: [validate]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Fail if any required job did not pass
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -11,12 +11,17 @@ on:
     paths:
       - ".github/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

A hostile audit of the template surfaced a cluster of issues where the repo violated its own `CLAUDE.md` rules and left CI under-guarded. This PR fixes the concrete, unambiguous ones.

## Changes

**Error-handling policy violations (`|| true` is forbidden by CLAUDE.md)**
- `template-sync.sh`: drop `|| true` from the changelog `git log` calls (the `cat-file -e` guard already proves the ref exists) and from the `ls-tree` deleted-file scan. The conflict-report diff is restructured to capture output into a variable and truncate with a here-string, so `head` truncation can't SIGPIPE `diff` and trip `set -e`.
- `validate-config.sh`: replace `read … || true` with `rc=0; read … || rc=$?` and branch on the code (EOF=1 is fine for empty files; >1 is a real read error reported loudly).
- `fetch-security-report.sh`: replace `|| true` on the per-PR comment fetch with an explicit `if !` that tolerates a single transient/permission failure without aborting the whole report.

**Fail loudly on missing input**
- `phone-home-extract.js` / `phone-home-submit.js`: validate the required env vars (`TEMPLATE_REPO`, `PR_TITLE`, `PR_URL`, `SOURCE_REPO`) and throw a clear error instead of casting `undefined` to `string` and emitting garbage into the issue body. The now-redundant `@type` casts are removed (`@ts-check` narrows after the guard).

**CI hardening**
- Add `timeout-minutes` to every workflow/job — the GitHub default of 360 min is a runaway-cost risk for a template that runs Claude sessions.
- Add `concurrency` groups so superseded PR runs are cancelled (PR-gating workflows) or serialized (`phone-home`, `dependabot-auto-merge`, `template-sync`).
- Track GitHub Actions versions via Dependabot (previously npm-only), so pinned action SHAs get update PRs.

**Portability**
- `run-hook-lifecycle.sh`: `#!/bin/bash` → `#!/usr/bin/env bash`, matching the other `.github/scripts/*.sh`.

## Deliberately *not* changed

An earlier pass added `*-passed` summary gates to `zizmor`, `gitleaks`, and `hook-lifecycle`. That was reverted: the README designates only `format-check`, `lint`, `node-tests`, `pre-commit`, and `validate-config` as Required checks, and adding a summary gate to a `paths`-filtered workflow (zizmor/hook-lifecycle) reintroduces the exact "Required check stuck pending forever" hazard that CLAUDE.md warns about.

## Verification

- `bash -n` + `shellcheck -x` clean on all modified shell scripts.
- `node --check` clean on both JS files; `prettier --check` passes.
- `validate-config.sh` runs green.
- Full Python suite: `60 passed`.
- All workflow + `dependabot.yml` YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjDcRAHdhZEE8D85sksgeg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjDcRAHdhZEE8D85sksgeg)_