### PR TITLE
docs: reorganize PR creation workflow to push before critique

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -66,9 +66,23 @@ Before updating an existing PR (pushing new commits, editing the description, 
 4. Review the changed files to understand the scope
 5. **Check for PR description guidance**—look for `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or similar files in the repo. If found, read them and adapt the PR description to follow the repository’s conventions (see [pr-templates.md](pr-templates.md) for details)
 
-### Step 2: Iterative Compress-Critique-Fix Loop
+### Step 2: Push and Create the Pull Request
 
-**Before creating the PR**, run an iterative loop until you reach a fixed point—a full critique pass that turns up nothing worth changing. This is the same loop described in `CLAUDE.md`’s Self-Critique Loop section; apply it here on the full diff.
+You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatting guidelines before this step.
+
+1. Push the branch: `git push -u origin HEAD`
+2. Check if a PR already exists for the current branch:
+   ```bash
+   EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
+   ```
+   If a PR already exists, update it with `gh pr edit` instead of creating a new one.
+3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
+
+### Step 3: Iterative Compress-Critique-Fix Loop
+
+CI is already running; use this time to improve the code.
+
+Run an iterative loop until you reach a fixed point—a full critique pass that turns up nothing worth changing. This is the same loop described in `CLAUDE.md`’s Self-Critique Loop section; apply it here on the full diff.
 
 You MUST read `.claude/skills/pr-creation/critique-prompt.md` once before the first pass—it contains the detailed checklist the sub-agent needs.
 
@@ -92,28 +106,18 @@ Each pass:
 
 **Skip the loop** for trivial changes (typo fixes, single-line config tweaks, pure docs edits)—say so explicitly when you skip.
 
-### Step 3: Run Validation
+### Step 4: Run Validation
 
-Run the project’s test/lint/typecheck commands (see [pr-templates.md](pr-templates.md) for common commands per language). Fix any failures before proceeding. If validation surfaces new defects, loop back into Step 2 with the fixes included.
-
-### Step 4: Push and Create the Pull Request
-
-You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatting guidelines before this step.
-
-1. Push the branch: `git push -u origin HEAD`
-2. Check if a PR already exists for the current branch:
-   ```bash
-   EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
-   ```
-   If a PR already exists, update it with `gh pr edit` instead of creating a new one.
-3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
+Run the project’s test/lint/typecheck commands (see [pr-templates.md](pr-templates.md) for common commands per language). Fix any failures before proceeding. If validation surfaces new defects, loop back into Step 3 with the fixes included.
 
 ### Step 5: Update PR Title and Description (after any post-creation changes)
 
-If you made any commits after creating the PR (from critique, validation, or CI failures), **always** update the PR title and description to reflect the final state of all changes:
+Push any commits made during the critique and validation steps, then update the PR to reflect the final state.
 
-1. Re-read the diff (`git diff $CLAUDE_CODE_BASE_REF...HEAD`) and commit log (`git log $CLAUDE_CODE_BASE_REF..HEAD --oneline`) to see the full scope
-2. Rewrite the title and body to accurately describe the **current totality** of changes, not just the original scope:
+1. Push: `git push`
+
+2. Re-read the diff (`git diff $CLAUDE_CODE_BASE_REF...HEAD`) and commit log (`git log $CLAUDE_CODE_BASE_REF..HEAD --oneline`) to see the full scope
+3. Rewrite the title and body to accurately describe the **current totality** of changes, not just the original scope:
    ```bash
    gh pr edit <pr-number> --title "<type>: <updated description>" --body "$(cat <<'EOF'
    <updated body using template from pr-templates.md>
@@ -121,7 +125,7 @@ If you made any commits after creating the PR (from critique, validation, or 
    )"
    ```
 
-Skip this step if no commits were made after Step 4.
+Skip the description update if no commits were made after Step 2.
 
 ### Step 6: Wait for CI Checks (MANDATORY)
 
@@ -140,7 +144,7 @@ After reporting the result, briefly reflect on how you could have iterated fast
 
 - **Parallelization**: Which investigations, tool calls, or sub-agent launches could have run in parallel instead of sequentially?
 - **Targeted checks over full sweeps**: Were there broad searches or full test runs you ran locally that CI would have caught anyway? Could a more targeted check (single file, single test, quick lint) have been faster?
-- **Earlier CI delegation**: Could you have pushed earlier and let CI surface issues rather than exhaustively validating locally first?
+- **Earlier CI delegation**: CI started at Step 2; did the critique loop or local validation catch issues CI would have caught anyway?
 - **Critique loop efficiency**: Did any critique passes surface issues that a quick re-read would have caught before launching the sub-agent?
 
 State each insight as one concrete line. Skip this step if the task was trivial (single-file, no iteration needed).
@@ -155,15 +159,12 @@ State each insight as one concrete line. Skip this step if the task was trivia
 
 1. Runs `git diff $CLAUDE_CODE_BASE_REF...HEAD`—sees changes in `src/auth/login.ts` and `tests/auth/login.test.ts`
 2. Runs `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline`—sees 2 commits
-3. Launches critique sub-agent with the diff
-4. Critique returns: “Looks good, minor suggestion to add null check on line 42”
-5. Fixes the null check, commits: `fix: add null check for empty session token`
-6. Runs `pnpm check && pnpm test && pnpm lint`—all pass
-7. Pushes and creates PR:
-   ```
-   gh pr create --title "fix: handle null session token in login flow" --body "..."
-   ```
-8. Updates PR description to reflect the null-check fix added during critique
+3. Pushes and creates PR: `gh pr create --title "fix: handle null session token in login flow" --body "..."`—CI starts immediately
+4. Launches critique sub-agent with the diff
+5. Critique returns: “Looks good, minor suggestion to add null check on line 42”
+6. Fixes the null check, commits: `fix: add null check for empty session token`
+7. Runs `pnpm check && pnpm test && pnpm lint`—all pass
+8. Pushes fixes, updates PR description to reflect the null-check fix
 9. Watches CI with `gh pr checks 47 --watch`—all green
 10. Reports: “PR #47 created and all CI checks pass: https://github.com/org/repo/pull/47"
 
@@ -175,12 +176,12 @@ State each insight as one concrete line. Skip this step if the task was trivia
 
 1. Runs `git diff $CLAUDE_CODE_BASE_REF...HEAD`—sees changes across 8 files including new components, tests, and API routes
 2. Runs `git log $CLAUDE_CODE_BASE_REF..HEAD --oneline`—sees 5 commits
-3. **Pass 1:** Critique flags 4 issues—unused import, two near-identical tests that should parametrize, duplicated validation logic across 2 components, an over-engineered single-caller wrapper. Fixes them: deletes the import, collapses the tests with `it.each`, extracts a shared `validateInput` helper for the duplication, inlines the single-caller wrapper. Commits.
-4. **Pass 2:** Critique flags 2 more—a leftover WHAT-comment from the refactor and a nested conditional. Un-nests and removes the comment. Commits.
-5. **Pass 3:** Critique returns clean—fixed point reached, exit loop.
-6. Runs validation—all pass
-7. Pushes and creates PR with detailed body summarizing the feature
-8. Updates PR title and description to reflect all changes including critique fixes
+3. Pushes and creates PR with a draft description—CI starts immediately
+4. **Pass 1:** Critique flags 4 issues—unused import, two near-identical tests that should parametrize, duplicated validation logic across 2 components, an over-engineered single-caller wrapper. Fixes them: deletes the import, collapses the tests with `it.each`, extracts a shared `validateInput` helper for the duplication, inlines the single-caller wrapper. Commits.
+5. **Pass 2:** Critique flags 2 more—a leftover WHAT-comment from the refactor and a nested conditional. Un-nests and removes the comment. Commits.
+6. **Pass 3:** Critique returns clean—fixed point reached, exit loop.
+7. Runs validation—all pass
+8. Pushes fixes, updates PR title and description to reflect all changes
 9. Watches CI—one check fails (lint warning on new file)
 10. Fixes lint issue, pushes, updates PR description again—all green
 11. Reports success with PR URL


### PR DESCRIPTION
## Summary

Reorganizes the PR creation skill to push the branch and create the PR *before* running the critique loop, allowing CI to run in parallel with code review and validation work.

## Changes

- **Reorder workflow steps**: Push and create PR moved from Step 4 to Step 2, before critique and validation
  - Critique loop is now Step 3 (was Step 2)
  - Validation is now Step 4 (was Step 3)
  - PR description update is now Step 5 (was Step 5, but with updated guidance)
  - CI wait is now Step 6 (was Step 6)

- **Update step descriptions** to reflect the new parallelization:
  - Step 2 now includes the push and PR creation workflow with template guidance
  - Step 3 notes that "CI is already running; use this time to improve the code"
  - Step 4 validation now loops back to Step 3 (not Step 2) if new defects surface
  - Step 5 guidance clarified: push commits first, then update PR description

- **Update examples** to show the new workflow:
  - Both simple and complex examples now create the PR before critique
  - Reflect that CI starts immediately after Step 2
  - Show commits made during critique/validation being pushed in Step 5

- **Refine reflection guidance** (Step 6): Changed "Earlier CI delegation" to ask whether critique or local validation caught issues CI would have caught anyway, since CI now starts at Step 2

## Rationale

This change enables better parallelization: CI validation runs while the developer is performing critique and local validation, reducing total wall-clock time. The PR is created earlier with a draft description, and refined after all improvements are complete.

https://claude.ai/code/session_01SEX1tJQaud4ZgCxbuFtpuu